### PR TITLE
SYS-1840: reorganize item edit UI

### DIFF
--- a/ftva_lab_data/templates/add_edit_item.html
+++ b/ftva_lab_data/templates/add_edit_item.html
@@ -5,73 +5,93 @@
 {% block content %}
 
 {% if messages %}
-    <div class="alert alert-success">
-        {% for message in messages %}
-            {{ message }}
-        {% endfor %}
-    </div>
+<div class="alert alert-success">
+    {% for message in messages %}
+    {{ message }}
+    {% endfor %}
+</div>
 {% endif %}
 
 <div class="container">
     <h1>{{ title }}</h1>
-    <form name = "item_form" id = "item_form" method="post" enctype="multipart/form-data">
+    <!-- Buttons -->
+    <div class="d-flex justify-content-start gap-2 mb-3">
+        <button id="toggle-advanced-fields" class="btn btn-secondary" type="button"
+            hx-on:click="toggleAdvancedFields(this)">Show Advanced Fields</button>
+        <button class="btn btn-primary" type="submit" form="item_form">{{ button_text }}</button>
+    </div>
+
+    <form name="item_form" id="item_form" method="post" enctype="multipart/form-data">
         {% csrf_token %}
-        <div id = "basic-fields">
-            {% bootstrap_field form.hard_drive_name %}
-            {% bootstrap_field form.dml_lto_tape_id %}
-            {% bootstrap_field form.arsc_lto_tape_id %}
-            {% bootstrap_field form.hard_drive_barcode_id %}
-            {% bootstrap_field form.file_folder_name %}
-            {% bootstrap_field form.sub_folder_name %}
-            {% bootstrap_field form.file_name %}
-            {% bootstrap_field form.inventory_number %}
-            {% bootstrap_field form.source_inventory_number %}
-            {% bootstrap_field form.source_barcode %}
-            {% bootstrap_field form.title %}
-        </div>
-        {% bootstrap_button "Show Advanced Fields" button_type="button" id="toggle-advanced-fields" button_class="btn-secondary" %}
-        <div id="advanced-fields" style="display: none;" class="mt-3">
-            {% bootstrap_field form.source_type %}
-            {% bootstrap_field form.resolution %}
-            {% bootstrap_field form.compression %}
-            {% bootstrap_field form.file_format %}
-            {% bootstrap_field form.file_size %}
-            {% bootstrap_field form.frame_rate %}
-            {% bootstrap_field form.total_running_time %}
-            {% bootstrap_field form.source_frame_rate %}
-            {% bootstrap_field form.aspect_ratio %}
-            {% bootstrap_field form.color_bit_depth %}
-            {% bootstrap_field form.color_type %}
-            {% bootstrap_field form.frame_layout %}
-            {% bootstrap_field form.sample_structure %}
-            {% bootstrap_field form.sample_rate %}
-            {% bootstrap_field form.capture_device_make_and_model %}
-            {% bootstrap_field form.capture_device_settings %}
-            {% bootstrap_field form.date_capture_completed %}
-            {% bootstrap_field form.video_edit_software_and_settings %}
-            {% bootstrap_field form.date_edit_completed %}
-            {% bootstrap_field form.color_grading_software %}
-            {% bootstrap_field form.color_grading_settings %}
-            {% bootstrap_field form.audio_file_format %}
-            {% bootstrap_field form.date_audio_edit_completed %}
-            {% bootstrap_field form.remaster_platform %}
-            {% bootstrap_field form.remaster_software %}
-            {% bootstrap_field form.remaster_settings %}
-            {% bootstrap_field form.date_remaster_completed %}
-            {% bootstrap_field form.subtitles %}
-            {% bootstrap_field form.watermark_type %}
-            {% bootstrap_field form.security_data_encrypted %}
-            {% bootstrap_field form.migration_or_preservation_record %}
-            {% bootstrap_field form.hard_drive_location %}
-            {% bootstrap_field form.date_job_started %}
-            {% bootstrap_field form.date_job_completed %}
-            {% bootstrap_field form.general_entry_cataloged_by %}
-            {% bootstrap_field form.notes %}
-        </div>
-        {% bootstrap_button button_text button_type="submit" %}
-    </form> 
-</div> 
+        <fieldset id="basic-fields" class="row" name="basic-fields" form="item_form">
+            <legend>Basic Fields</legend>
+            <div class="col">
+                {% bootstrap_field form.hard_drive_name %}
+                {% bootstrap_field form.dml_lto_tape_id %}
+                {% bootstrap_field form.arsc_lto_tape_id %}
+            </div>
+            <div class="col">
+                {% bootstrap_field form.hard_drive_barcode_id %}
+                {% bootstrap_field form.file_folder_name %}
+                {% bootstrap_field form.sub_folder_name %}
+            </div>
+            <div class="col">
+                {% bootstrap_field form.file_name %}
+                {% bootstrap_field form.inventory_number %}
+                {% bootstrap_field form.source_inventory_number %}
+            </div>
+        </fieldset>
+
+        <fieldset id="advanced-fields" class="row mt-3" name="advanced-fields" form="item_form" hidden>
+            <legend>Advanced Fields</legend>
+            <div class="col">
+                {% bootstrap_field form.source_barcode %}
+                {% bootstrap_field form.title %}
+                {% bootstrap_field form.source_type %}
+                {% bootstrap_field form.resolution %}
+                {% bootstrap_field form.compression %}
+                {% bootstrap_field form.file_format %}
+                {% bootstrap_field form.file_size %}
+                {% bootstrap_field form.frame_rate %}
+                {% bootstrap_field form.total_running_time %}
+                {% bootstrap_field form.source_frame_rate %}
+            </div>
+            <div class="col">
+                {% bootstrap_field form.aspect_ratio %}
+                {% bootstrap_field form.color_bit_depth %}
+                {% bootstrap_field form.color_type %}
+                {% bootstrap_field form.frame_layout %}
+                {% bootstrap_field form.sample_structure %}
+                {% bootstrap_field form.sample_rate %}
+                {% bootstrap_field form.capture_device_make_and_model %}
+                {% bootstrap_field form.capture_device_settings %}
+                {% bootstrap_field form.date_capture_completed %}
+                {% bootstrap_field form.video_edit_software_and_settings %}
+            </div>
+            <div class="col">
+                {% bootstrap_field form.date_edit_completed %}
+                {% bootstrap_field form.color_grading_software %}
+                {% bootstrap_field form.color_grading_settings %}
+                {% bootstrap_field form.audio_file_format %}
+                {% bootstrap_field form.date_audio_edit_completed %}
+                {% bootstrap_field form.remaster_platform %}
+                {% bootstrap_field form.remaster_software %}
+                {% bootstrap_field form.remaster_settings %}
+                {% bootstrap_field form.date_remaster_completed %}
+                {% bootstrap_field form.subtitles %}
+            </div>
+            <div class="col">
+                {% bootstrap_field form.watermark_type %}
+                {% bootstrap_field form.security_data_encrypted %}
+                {% bootstrap_field form.migration_or_preservation_record %}
+                {% bootstrap_field form.hard_drive_location %}
+                {% bootstrap_field form.date_job_started %}
+                {% bootstrap_field form.date_job_completed %}
+                {% bootstrap_field form.general_entry_cataloged_by %}
+                {% bootstrap_field form.notes %}
+            </div>
+        </fieldset>
+    </form>
+</div>
 
 {% endblock %}
-
-

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -1,15 +1,7 @@
-let toggleAdvancedFields = document.getElementById("toggle-advanced-fields");
-if (toggleAdvancedFields) {
-  toggleAdvancedFields.addEventListener("click", function () {
-    const advancedFields = document.getElementById("advanced-fields");
-    if (advancedFields.style.display === "none") {
-      advancedFields.style.display = "block";
-      this.textContent = "Hide Advanced Fields";
-    } else {
-      advancedFields.style.display = "none";
-      this.textContent = "Show Advanced Fields";
-    }
-  });
+function toggleAdvancedFields(el) {
+  const advancedFields = document.getElementById("advanced-fields");
+  const isHidden = advancedFields.hidden = !advancedFields.hidden;
+  el.textContent = isHidden ? "Show Advanced Fields" : "Hide Advanced Fields";
 }
 
 function clearSearchInput() {


### PR DESCRIPTION
Implements [SYS-1840](https://uclalibrary.atlassian.net/browse/SYS-1840)

#### Acceptance criteria
- ✅ Redesign the edit_item screen to make better use of wide-screen monitors
- ✅ Try to fit the first 9 fields (hard_drive_name through source_inventory_number) into the top half of the screen, via 2-3 columns
  - Using Bootstrap's grid system, I used 3 columns for the Basic Fields section
- ✅ The remaining fields could be handled in 4-5 columns, as most have short values
  - I used 4 columns for the remaining Advanced Fields section

#### Other changes
I moved the buttons from below to above the form, to avoid the `Save` button jumping to the bottom when the `Advanced Fields` section is revealed. I also changed the buttons to vanilla HTML button elements with Bootstrap classes, rather than `django-bootstrap5` template imports, as I couldn't figure out how to add HTMX attributes to `{% bootstrap_button %}`. It didn't appear to be able to expand the HTMX attribute, which uses `hx-` as a prefix, as a keyword argument for the underlying method call.

I also changed the enclosing tag around the two field sections (Basic Fields and Advanced Fields) from `<div>` to `<fieldset>`, just to be a bit more semantic.

The changes to the JavaScript file just wraps the toggle for Show/Hide Advanced Fields in a function and refactors it a bit.