### PR TITLE
SYS-1841: restrict editing, add login, and add user-creation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,18 @@ Certain views within the application are restricted to users with appropriate pe
 
 ```python manage.py loaddata groups_and_permissions.json```
 
+#### Loading users
+
+FTVA staff provided a list of users in a Google Sheet. Ask a teammate for the sheet, if need be. Users can be loaded from the sheet using the following management command:
+
+```python manage.py create_users_from_sheet -f {SPREADSHEET_PATH}.xlsx```
+
+The script accepts two command line arguments:
+
+- `-f` (or `--file_name`) _required_: path to an Excel (XLSX) export of the FTVA Google Sheet containing user data
+- `--email_users`: whether to email users with a link to set their passwords
+  - NOTE: the emailing logic is not currently implemented. This feature will be added later.
+
 ### Logging
 
 Basic logging is available, with logs captured in `logs/application.log`.  At present, logs from both the custom application code and Django itself are captured.

--- a/README.md
+++ b/README.md
@@ -105,6 +105,12 @@ The container runs via `docker_scripts/entrypoint.sh`, which
 
    ```Installed 26653 object(s) from 1 fixture(s)```
 
+#### Loading group and permission definitions
+
+Certain views within the application are restricted to users with appropriate permissions. Corresponding group and permission definitions are included in the `groups_and_permissions.json` fixture.  This can be loaded using:
+
+```python manage.py loaddata groups_and_permissions.json```
+
 ### Logging
 
 Basic logging is available, with logs captured in `logs/application.log`.  At present, logs from both the custom application code and Django itself are captured.

--- a/docker_scripts/entrypoint.sh
+++ b/docker_scripts/entrypoint.sh
@@ -25,7 +25,7 @@ if [ "$DJANGO_RUN_ENV" = "dev" ]; then
   python manage.py createsuperuser --no-input
 
   # Load fixtures, only in dev environment.
-  python manage.py loaddata sample_data.json
+  python manage.py loaddata sample_data.json groups_and_permissions.json
 fi
 
 if [ "$DJANGO_RUN_ENV" = "dev" ]; then

--- a/ftva_lab_data/fixtures/groups_and_permissions.json
+++ b/ftva_lab_data/fixtures/groups_and_permissions.json
@@ -1,277 +1,357 @@
 [
-{
-  "model": "auth.group",
-  "pk": 1,
-  "fields": {
-    "name": "editors",
-    "permissions": [
-      34,
-      35,
-      36,
-      37
-    ]
+  {
+    "model": "auth.permission",
+    "pk": 1,
+    "fields": {
+      "name": "Can add log entry",
+      "content_type": [
+        "admin",
+        "logentry"
+      ],
+      "codename": "add_logentry"
+    }
+  },
+  {
+    "model": "auth.permission",
+    "pk": 2,
+    "fields": {
+      "name": "Can change log entry",
+      "content_type": [
+        "admin",
+        "logentry"
+      ],
+      "codename": "change_logentry"
+    }
+  },
+  {
+    "model": "auth.permission",
+    "pk": 3,
+    "fields": {
+      "name": "Can delete log entry",
+      "content_type": [
+        "admin",
+        "logentry"
+      ],
+      "codename": "delete_logentry"
+    }
+  },
+  {
+    "model": "auth.permission",
+    "pk": 4,
+    "fields": {
+      "name": "Can view log entry",
+      "content_type": [
+        "admin",
+        "logentry"
+      ],
+      "codename": "view_logentry"
+    }
+  },
+  {
+    "model": "auth.permission",
+    "pk": 5,
+    "fields": {
+      "name": "Can add permission",
+      "content_type": [
+        "auth",
+        "permission"
+      ],
+      "codename": "add_permission"
+    }
+  },
+  {
+    "model": "auth.permission",
+    "pk": 6,
+    "fields": {
+      "name": "Can change permission",
+      "content_type": [
+        "auth",
+        "permission"
+      ],
+      "codename": "change_permission"
+    }
+  },
+  {
+    "model": "auth.permission",
+    "pk": 7,
+    "fields": {
+      "name": "Can delete permission",
+      "content_type": [
+        "auth",
+        "permission"
+      ],
+      "codename": "delete_permission"
+    }
+  },
+  {
+    "model": "auth.permission",
+    "pk": 8,
+    "fields": {
+      "name": "Can view permission",
+      "content_type": [
+        "auth",
+        "permission"
+      ],
+      "codename": "view_permission"
+    }
+  },
+  {
+    "model": "auth.permission",
+    "pk": 9,
+    "fields": {
+      "name": "Can add group",
+      "content_type": [
+        "auth",
+        "group"
+      ],
+      "codename": "add_group"
+    }
+  },
+  {
+    "model": "auth.permission",
+    "pk": 10,
+    "fields": {
+      "name": "Can change group",
+      "content_type": [
+        "auth",
+        "group"
+      ],
+      "codename": "change_group"
+    }
+  },
+  {
+    "model": "auth.permission",
+    "pk": 11,
+    "fields": {
+      "name": "Can delete group",
+      "content_type": [
+        "auth",
+        "group"
+      ],
+      "codename": "delete_group"
+    }
+  },
+  {
+    "model": "auth.permission",
+    "pk": 12,
+    "fields": {
+      "name": "Can view group",
+      "content_type": [
+        "auth",
+        "group"
+      ],
+      "codename": "view_group"
+    }
+  },
+  {
+    "model": "auth.permission",
+    "pk": 13,
+    "fields": {
+      "name": "Can add user",
+      "content_type": [
+        "auth",
+        "user"
+      ],
+      "codename": "add_user"
+    }
+  },
+  {
+    "model": "auth.permission",
+    "pk": 14,
+    "fields": {
+      "name": "Can change user",
+      "content_type": [
+        "auth",
+        "user"
+      ],
+      "codename": "change_user"
+    }
+  },
+  {
+    "model": "auth.permission",
+    "pk": 15,
+    "fields": {
+      "name": "Can delete user",
+      "content_type": [
+        "auth",
+        "user"
+      ],
+      "codename": "delete_user"
+    }
+  },
+  {
+    "model": "auth.permission",
+    "pk": 16,
+    "fields": {
+      "name": "Can view user",
+      "content_type": [
+        "auth",
+        "user"
+      ],
+      "codename": "view_user"
+    }
+  },
+  {
+    "model": "auth.permission",
+    "pk": 17,
+    "fields": {
+      "name": "Can add content type",
+      "content_type": [
+        "contenttypes",
+        "contenttype"
+      ],
+      "codename": "add_contenttype"
+    }
+  },
+  {
+    "model": "auth.permission",
+    "pk": 18,
+    "fields": {
+      "name": "Can change content type",
+      "content_type": [
+        "contenttypes",
+        "contenttype"
+      ],
+      "codename": "change_contenttype"
+    }
+  },
+  {
+    "model": "auth.permission",
+    "pk": 19,
+    "fields": {
+      "name": "Can delete content type",
+      "content_type": [
+        "contenttypes",
+        "contenttype"
+      ],
+      "codename": "delete_contenttype"
+    }
+  },
+  {
+    "model": "auth.permission",
+    "pk": 20,
+    "fields": {
+      "name": "Can view content type",
+      "content_type": [
+        "contenttypes",
+        "contenttype"
+      ],
+      "codename": "view_contenttype"
+    }
+  },
+  {
+    "model": "auth.permission",
+    "pk": 21,
+    "fields": {
+      "name": "Can add session",
+      "content_type": [
+        "sessions",
+        "session"
+      ],
+      "codename": "add_session"
+    }
+  },
+  {
+    "model": "auth.permission",
+    "pk": 22,
+    "fields": {
+      "name": "Can change session",
+      "content_type": [
+        "sessions",
+        "session"
+      ],
+      "codename": "change_session"
+    }
+  },
+  {
+    "model": "auth.permission",
+    "pk": 23,
+    "fields": {
+      "name": "Can delete session",
+      "content_type": [
+        "sessions",
+        "session"
+      ],
+      "codename": "delete_session"
+    }
+  },
+  {
+    "model": "auth.permission",
+    "pk": 24,
+    "fields": {
+      "name": "Can view session",
+      "content_type": [
+        "sessions",
+        "session"
+      ],
+      "codename": "view_session"
+    }
+  },
+  {
+    "model": "auth.permission",
+    "pk": 25,
+    "fields": {
+      "name": "Can add sheet import",
+      "content_type": [
+        "ftva_lab_data",
+        "sheetimport"
+      ],
+      "codename": "add_sheetimport"
+    }
+  },
+  {
+    "model": "auth.permission",
+    "pk": 26,
+    "fields": {
+      "name": "Can change sheet import",
+      "content_type": [
+        "ftva_lab_data",
+        "sheetimport"
+      ],
+      "codename": "change_sheetimport"
+    }
+  },
+  {
+    "model": "auth.permission",
+    "pk": 27,
+    "fields": {
+      "name": "Can delete sheet import",
+      "content_type": [
+        "ftva_lab_data",
+        "sheetimport"
+      ],
+      "codename": "delete_sheetimport"
+    }
+  },
+  {
+    "model": "auth.permission",
+    "pk": 28,
+    "fields": {
+      "name": "Can view sheet import",
+      "content_type": [
+        "ftva_lab_data",
+        "sheetimport"
+      ],
+      "codename": "view_sheetimport"
+    }
+  },
+  {
+    "model": "auth.group",
+    "pk": 1,
+    "fields": {
+      "name": "editors",
+      "permissions": [
+        [
+          "add_sheetimport",
+          "ftva_lab_data",
+          "sheetimport"
+        ],
+        [
+          "change_sheetimport",
+          "ftva_lab_data",
+          "sheetimport"
+        ]
+      ]
+    }
   }
-},
-{
-  "model": "auth.group",
-  "pk": 2,
-  "fields": {
-    "name": "view_only",
-    "permissions": [
-      37
-    ]
-  }
-},
-{
-  "model": "auth.permission",
-  "pk": 1,
-  "fields": {
-    "name": "Can add log entry",
-    "content_type": 1,
-    "codename": "add_logentry"
-  }
-},
-{
-  "model": "auth.permission",
-  "pk": 2,
-  "fields": {
-    "name": "Can change log entry",
-    "content_type": 1,
-    "codename": "change_logentry"
-  }
-},
-{
-  "model": "auth.permission",
-  "pk": 3,
-  "fields": {
-    "name": "Can delete log entry",
-    "content_type": 1,
-    "codename": "delete_logentry"
-  }
-},
-{
-  "model": "auth.permission",
-  "pk": 4,
-  "fields": {
-    "name": "Can view log entry",
-    "content_type": 1,
-    "codename": "view_logentry"
-  }
-},
-{
-  "model": "auth.permission",
-  "pk": 5,
-  "fields": {
-    "name": "Can add permission",
-    "content_type": 2,
-    "codename": "add_permission"
-  }
-},
-{
-  "model": "auth.permission",
-  "pk": 6,
-  "fields": {
-    "name": "Can change permission",
-    "content_type": 2,
-    "codename": "change_permission"
-  }
-},
-{
-  "model": "auth.permission",
-  "pk": 7,
-  "fields": {
-    "name": "Can delete permission",
-    "content_type": 2,
-    "codename": "delete_permission"
-  }
-},
-{
-  "model": "auth.permission",
-  "pk": 8,
-  "fields": {
-    "name": "Can view permission",
-    "content_type": 2,
-    "codename": "view_permission"
-  }
-},
-{
-  "model": "auth.permission",
-  "pk": 9,
-  "fields": {
-    "name": "Can add group",
-    "content_type": 3,
-    "codename": "add_group"
-  }
-},
-{
-  "model": "auth.permission",
-  "pk": 10,
-  "fields": {
-    "name": "Can change group",
-    "content_type": 3,
-    "codename": "change_group"
-  }
-},
-{
-  "model": "auth.permission",
-  "pk": 11,
-  "fields": {
-    "name": "Can delete group",
-    "content_type": 3,
-    "codename": "delete_group"
-  }
-},
-{
-  "model": "auth.permission",
-  "pk": 12,
-  "fields": {
-    "name": "Can view group",
-    "content_type": 3,
-    "codename": "view_group"
-  }
-},
-{
-  "model": "auth.permission",
-  "pk": 13,
-  "fields": {
-    "name": "Can add user",
-    "content_type": 4,
-    "codename": "add_user"
-  }
-},
-{
-  "model": "auth.permission",
-  "pk": 14,
-  "fields": {
-    "name": "Can change user",
-    "content_type": 4,
-    "codename": "change_user"
-  }
-},
-{
-  "model": "auth.permission",
-  "pk": 15,
-  "fields": {
-    "name": "Can delete user",
-    "content_type": 4,
-    "codename": "delete_user"
-  }
-},
-{
-  "model": "auth.permission",
-  "pk": 16,
-  "fields": {
-    "name": "Can view user",
-    "content_type": 4,
-    "codename": "view_user"
-  }
-},
-{
-  "model": "auth.permission",
-  "pk": 17,
-  "fields": {
-    "name": "Can add content type",
-    "content_type": 5,
-    "codename": "add_contenttype"
-  }
-},
-{
-  "model": "auth.permission",
-  "pk": 18,
-  "fields": {
-    "name": "Can change content type",
-    "content_type": 5,
-    "codename": "change_contenttype"
-  }
-},
-{
-  "model": "auth.permission",
-  "pk": 19,
-  "fields": {
-    "name": "Can delete content type",
-    "content_type": 5,
-    "codename": "delete_contenttype"
-  }
-},
-{
-  "model": "auth.permission",
-  "pk": 20,
-  "fields": {
-    "name": "Can view content type",
-    "content_type": 5,
-    "codename": "view_contenttype"
-  }
-},
-{
-  "model": "auth.permission",
-  "pk": 21,
-  "fields": {
-    "name": "Can add session",
-    "content_type": 6,
-    "codename": "add_session"
-  }
-},
-{
-  "model": "auth.permission",
-  "pk": 22,
-  "fields": {
-    "name": "Can change session",
-    "content_type": 6,
-    "codename": "change_session"
-  }
-},
-{
-  "model": "auth.permission",
-  "pk": 23,
-  "fields": {
-    "name": "Can delete session",
-    "content_type": 6,
-    "codename": "delete_session"
-  }
-},
-{
-  "model": "auth.permission",
-  "pk": 24,
-  "fields": {
-    "name": "Can view session",
-    "content_type": 6,
-    "codename": "view_session"
-  }
-},
-{
-  "model": "auth.permission",
-  "pk": 34,
-  "fields": {
-    "name": "Can add sheet import",
-    "content_type": 34,
-    "codename": "add_sheetimport"
-  }
-},
-{
-  "model": "auth.permission",
-  "pk": 35,
-  "fields": {
-    "name": "Can change sheet import",
-    "content_type": 34,
-    "codename": "change_sheetimport"
-  }
-},
-{
-  "model": "auth.permission",
-  "pk": 36,
-  "fields": {
-    "name": "Can delete sheet import",
-    "content_type": 34,
-    "codename": "delete_sheetimport"
-  }
-},
-{
-  "model": "auth.permission",
-  "pk": 37,
-  "fields": {
-    "name": "Can view sheet import",
-    "content_type": 34,
-    "codename": "view_sheetimport"
-  }
-}
 ]

--- a/ftva_lab_data/fixtures/groups_and_permissions.json
+++ b/ftva_lab_data/fixtures/groups_and_permissions.json
@@ -1,0 +1,277 @@
+[
+{
+  "model": "auth.group",
+  "pk": 1,
+  "fields": {
+    "name": "editors",
+    "permissions": [
+      34,
+      35,
+      36,
+      37
+    ]
+  }
+},
+{
+  "model": "auth.group",
+  "pk": 2,
+  "fields": {
+    "name": "view_only",
+    "permissions": [
+      37
+    ]
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 1,
+  "fields": {
+    "name": "Can add log entry",
+    "content_type": 1,
+    "codename": "add_logentry"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 2,
+  "fields": {
+    "name": "Can change log entry",
+    "content_type": 1,
+    "codename": "change_logentry"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 3,
+  "fields": {
+    "name": "Can delete log entry",
+    "content_type": 1,
+    "codename": "delete_logentry"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 4,
+  "fields": {
+    "name": "Can view log entry",
+    "content_type": 1,
+    "codename": "view_logentry"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 5,
+  "fields": {
+    "name": "Can add permission",
+    "content_type": 2,
+    "codename": "add_permission"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 6,
+  "fields": {
+    "name": "Can change permission",
+    "content_type": 2,
+    "codename": "change_permission"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 7,
+  "fields": {
+    "name": "Can delete permission",
+    "content_type": 2,
+    "codename": "delete_permission"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 8,
+  "fields": {
+    "name": "Can view permission",
+    "content_type": 2,
+    "codename": "view_permission"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 9,
+  "fields": {
+    "name": "Can add group",
+    "content_type": 3,
+    "codename": "add_group"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 10,
+  "fields": {
+    "name": "Can change group",
+    "content_type": 3,
+    "codename": "change_group"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 11,
+  "fields": {
+    "name": "Can delete group",
+    "content_type": 3,
+    "codename": "delete_group"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 12,
+  "fields": {
+    "name": "Can view group",
+    "content_type": 3,
+    "codename": "view_group"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 13,
+  "fields": {
+    "name": "Can add user",
+    "content_type": 4,
+    "codename": "add_user"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 14,
+  "fields": {
+    "name": "Can change user",
+    "content_type": 4,
+    "codename": "change_user"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 15,
+  "fields": {
+    "name": "Can delete user",
+    "content_type": 4,
+    "codename": "delete_user"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 16,
+  "fields": {
+    "name": "Can view user",
+    "content_type": 4,
+    "codename": "view_user"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 17,
+  "fields": {
+    "name": "Can add content type",
+    "content_type": 5,
+    "codename": "add_contenttype"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 18,
+  "fields": {
+    "name": "Can change content type",
+    "content_type": 5,
+    "codename": "change_contenttype"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 19,
+  "fields": {
+    "name": "Can delete content type",
+    "content_type": 5,
+    "codename": "delete_contenttype"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 20,
+  "fields": {
+    "name": "Can view content type",
+    "content_type": 5,
+    "codename": "view_contenttype"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 21,
+  "fields": {
+    "name": "Can add session",
+    "content_type": 6,
+    "codename": "add_session"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 22,
+  "fields": {
+    "name": "Can change session",
+    "content_type": 6,
+    "codename": "change_session"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 23,
+  "fields": {
+    "name": "Can delete session",
+    "content_type": 6,
+    "codename": "delete_session"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 24,
+  "fields": {
+    "name": "Can view session",
+    "content_type": 6,
+    "codename": "view_session"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 34,
+  "fields": {
+    "name": "Can add sheet import",
+    "content_type": 34,
+    "codename": "add_sheetimport"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 35,
+  "fields": {
+    "name": "Can change sheet import",
+    "content_type": 34,
+    "codename": "change_sheetimport"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 36,
+  "fields": {
+    "name": "Can delete sheet import",
+    "content_type": 34,
+    "codename": "delete_sheetimport"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 37,
+  "fields": {
+    "name": "Can view sheet import",
+    "content_type": 34,
+    "codename": "view_sheetimport"
+  }
+}
+]

--- a/ftva_lab_data/management/commands/create_users_from_sheet.py
+++ b/ftva_lab_data/management/commands/create_users_from_sheet.py
@@ -27,7 +27,7 @@ class Command(BaseCommand):
         # `sheet_name=None` means read all sheets into a dict of DataFrames
         sheet_dict = pd.read_excel(file_name, sheet_name=None)
         for sheet_name in sheet_dict.keys():
-            group, _ = Group.objects.get_or_create(name=sheet_name)
+            editors_group, _ = Group.objects.get_or_create(name="editors")
             df = sheet_dict[sheet_name]
             for index, row in df.iterrows():
                 # Avoid resetting passwords for existing users
@@ -38,8 +38,9 @@ class Command(BaseCommand):
                         first_name=row["first_name"],
                         last_name=row["last_name"],
                     )
-                    # Group comes from name of sheet in input spreadsheet
-                    user.groups.add(group)
+                    # Editors group is the only useful one for now
+                    if sheet_name.lower() == "editors":
+                        user.groups.add(editors_group)
                     user.set_unusable_password()
                     user.save()
                     print(f"Created {user.username}")

--- a/ftva_lab_data/management/commands/create_users_from_sheet.py
+++ b/ftva_lab_data/management/commands/create_users_from_sheet.py
@@ -1,0 +1,53 @@
+import pandas as pd
+from django.core.management.base import BaseCommand
+from django.contrib.auth.models import User, Group
+
+
+class Command(BaseCommand):
+    help = "Create users from export of Google Sheet provided by FTVA staff"
+
+    def add_arguments(self, parser) -> None:
+        parser.add_argument(
+            "-f",
+            "--file_name",
+            type=str,
+            required=True,
+            help="Path to the XLSX export of Google Sheet",
+        )
+
+        parser.add_argument(
+            "--email_users",
+            action="store_true",
+            default=False,
+            help="Email users with their password reset link",
+        )
+
+    def handle(self, *args, **options) -> None:
+        file_name = options["file_name"]
+        # `sheet_name=None` means read all sheets into a dict of DataFrames
+        sheet_dict = pd.read_excel(file_name, sheet_name=None)
+        for sheet_name in sheet_dict.keys():
+            group, _ = Group.objects.get_or_create(name=sheet_name)
+            df = sheet_dict[sheet_name]
+            for index, row in df.iterrows():
+                # Avoid resetting passwords for existing users
+                if not User.objects.filter(username=row["username"]).exists():
+                    user = User.objects.create(
+                        username=row["username"],
+                        email=row["email"],
+                        first_name=row["first_name"],
+                        last_name=row["last_name"],
+                    )
+                    # Group comes from name of sheet in input spreadsheet
+                    user.groups.add(group)
+                    user.set_unusable_password()
+                    user.save()
+                    print(f"Created {user.username}")
+
+                    if options["email_users"]:
+                        # TODO: email users with link to reset password
+                        print(
+                            f"[TODO] Sent email with link to reset password to {user.email}"
+                        )
+                else:
+                    print(f"{row['username']} already exists")

--- a/ftva_lab_data/management/commands/create_users_from_sheet.py
+++ b/ftva_lab_data/management/commands/create_users_from_sheet.py
@@ -26,8 +26,13 @@ class Command(BaseCommand):
         file_name = options["file_name"]
         # `sheet_name=None` means read all sheets into a dict of DataFrames
         sheet_dict = pd.read_excel(file_name, sheet_name=None)
+
+        # 'editors' group should already exist, but just in case
+        try:
+            editors_group = Group.objects.get(name="editors")
+        except Group.DoesNotExist:
+            print("Group 'editors' does not exist")
         for sheet_name in sheet_dict.keys():
-            editors_group, _ = Group.objects.get_or_create(name="editors")
             df = sheet_dict[sheet_name]
             for index, row in df.iterrows():
                 # Avoid resetting passwords for existing users
@@ -39,7 +44,7 @@ class Command(BaseCommand):
                         last_name=row["last_name"],
                     )
                     # Editors group is the only useful one for now
-                    if sheet_name.lower() == "editors":
+                    if sheet_name.lower() == "editors" and editors_group:
                         user.groups.add(editors_group)
                     user.set_unusable_password()
                     user.save()

--- a/ftva_lab_data/templates/add_edit_item.html
+++ b/ftva_lab_data/templates/add_edit_item.html
@@ -18,7 +18,9 @@
             <button class="btn btn-primary" type="submit" form="item_form">{{ button_text }}</button>
         </div>
 
-        <a class="btn btn-outline-danger" href="{% url 'view_item' item.id %}">Cancel</a>
+        <a class="btn btn-outline-danger"
+            href="{% if item %}{% url 'view_item' item.id %}{% else %}{% url 'search_results' %}{% endif %}">
+            Cancel</a>
     </div>
 
     <form name="item_form" id="item_form" method="post" enctype="multipart/form-data">

--- a/ftva_lab_data/templates/registration/login.html
+++ b/ftva_lab_data/templates/registration/login.html
@@ -1,0 +1,16 @@
+{% extends 'base.html' %}
+
+{% load django_bootstrap5 %}
+
+{% block content %}
+<div class="h-100 d-flex justify-content-center align-items-center">
+    <div class="container w-50 p-5 bg-light rounded shadow-sm border">
+        <h1>Log In</h1>
+        <form method="post">
+            {% csrf_token %}
+            {% bootstrap_form form layout="horizontal" %}
+            {% bootstrap_button button_type="submit" content="Log In" %}
+        </form>
+    </div>
+</div>
+{% endblock %}

--- a/ftva_lab_data/templates/view_item.html
+++ b/ftva_lab_data/templates/view_item.html
@@ -18,7 +18,9 @@
         <div class="d-flex gap-2">
             <button id="toggle-advanced-fields" class="btn btn-secondary" type="button"
                 hx-on:click="toggleAdvancedFields(this)">Show Advanced Fields</button>
+            {% if perms.ftva_lab_data.change_sheetimport %}
             <a class="btn btn-primary" href="{% url 'edit_item' item.id %}">Edit This Record</a>
+            {% endif %}
         </div>
 
         <a class="btn btn-outline-secondary" href="{% url 'search_results' %}">Back to Search</a>

--- a/ftva_lab_data/tests.py
+++ b/ftva_lab_data/tests.py
@@ -1,6 +1,8 @@
-from django.test import TestCase
+from django.test import TestCase, Client
 from ftva_lab_data.models import SheetImport
 from django.contrib.auth import get_user_model
+from django.contrib.auth.models import User, Group, Permission
+from django.urls import reverse
 from ftva_lab_data.views_utils import get_field_value
 
 
@@ -33,3 +35,100 @@ class GetFieldValueTests(TestCase):
         # Test empty string field access
         value = get_field_value(self.item_without_user, "assigned_user__username")
         self.assertEqual(value, "")
+
+
+class AddEditItemTestCase(TestCase):
+    """Tests for the `add_item` and `edit_item` views."""
+
+    fixtures = ["sample_data.json"]
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        # Create client and SheetImport object for tests
+        cls.client = Client()
+        cls.test_object = SheetImport.objects.get(pk=2)
+        cls.test_form_data = {"file_name": "test_file_name.txt"}
+
+        # Create two users, one to add to editors group and one with no group
+        cls.unauthorized_user = User.objects.create_user(
+            username="unauthorized", password="testpassword"
+        )
+        cls.authorized_user = User.objects.create_user(
+            username="authorized", password="testpassword"
+        )
+
+        # Create editors group and add permissions to add and edit SheetImport
+        cls.editors_group, _ = Group.objects.get_or_create(name="editors")
+        cls.edit_permissions = Permission.objects.filter(
+            codename__in=["add_sheetimport", "change_sheetimport"]
+        )
+        cls.editors_group.permissions.add(*cls.edit_permissions)
+
+        # Add authorized user to the editors group
+        cls.authorized_user.groups.add(cls.editors_group)
+
+    def test_authorized_user_can_add(self):
+        """Asserts that user added to `editors` group in setup
+        can GET and POST to the `add_item` view.
+        """
+        self.client.login(username="authorized", password="testpassword")
+        url = reverse("add_item")
+
+        # GET request
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+        # POST request
+        response = self.client.post(url, data=self.test_form_data)
+        self.assertEqual(response.status_code, 302)  # POST should redirect
+        # Confirm item successfully added to database
+        new_item = SheetImport.objects.get(file_name=self.test_form_data["file_name"])
+        self.assertEqual(new_item.file_name, self.test_form_data["file_name"])
+
+    def test_authorized_user_can_edit(self):
+        """Asserts that user added to `editors` group in setup
+        can GET and POST to the `edit_item` view.
+        """
+        self.client.login(username="authorized", password="testpassword")
+        url = reverse("edit_item", args=[self.test_object.id])
+
+        # GET request
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+        # POST request
+        response = self.client.post(url, self.test_form_data)
+        self.assertEqual(response.status_code, 200)
+        # Confirm item successfully updated in database
+        self.test_object.refresh_from_db()
+        self.assertEqual(self.test_object.file_name, self.test_form_data["file_name"])
+
+    def test_unauthorized_user_cannot_add(self):
+        """Asserts that unauthorized user with no group receives 403
+        when trying to GET and POST to the `add_item` view.
+        """
+        self.client.login(username="unauthorized", password="testpassword")
+        url = reverse("add_item")
+
+        # GET request
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 403)
+
+        # POST request
+        response = self.client.post(url, self.test_form_data)
+        self.assertEqual(response.status_code, 403)
+
+    def test_unauthorized_user_cannot_edit(self):
+        """Asserts that unauthorized user with no group receives 403
+        when trying to GET and POST to the `edit_item` view.
+        """
+        self.client.login(username="unauthorized", password="testpassword")
+        url = reverse("edit_item", args=[self.test_object.id])
+
+        # GET request
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 403)
+
+        # POST request
+        response = self.client.post(url, self.test_form_data)
+        self.assertEqual(response.status_code, 403)

--- a/ftva_lab_data/tests.py
+++ b/ftva_lab_data/tests.py
@@ -1,7 +1,7 @@
 from django.test import TestCase, Client
 from ftva_lab_data.models import SheetImport
 from django.contrib.auth import get_user_model
-from django.contrib.auth.models import User, Group, Permission
+from django.contrib.auth.models import User, Group
 from django.urls import reverse
 from ftva_lab_data.views_utils import get_field_value
 
@@ -40,7 +40,7 @@ class GetFieldValueTests(TestCase):
 class UserAccessTestCase(TestCase):
     """Tests expected behavior for different users requesting various views."""
 
-    fixtures = ["sample_data.json"]
+    fixtures = ["sample_data.json", "groups_and_permissions.json"]
 
     @classmethod
     def setUpTestData(cls) -> None:
@@ -57,15 +57,10 @@ class UserAccessTestCase(TestCase):
             username="authorized", password="testpassword"
         )
 
-        # Create editors group and add permissions to add and edit SheetImport
-        cls.editors_group, _ = Group.objects.get_or_create(name="editors")
-        cls.edit_permissions = Permission.objects.filter(
-            codename__in=["add_sheetimport", "change_sheetimport"]
-        )
-        cls.editors_group.permissions.add(*cls.edit_permissions)
-
-        # Add authorized user to the editors group
-        cls.authorized_user.groups.add(cls.editors_group)
+        # Add authorized user to the editors group created in fixture
+        # which has necessary permissions for `add_item` and `edit_item` views
+        editors_group = Group.objects.get(name="editors")
+        cls.authorized_user.groups.add(editors_group)
 
     def test_authorized_user_can_add(self):
         """Asserts that user added to `editors` group in setup

--- a/ftva_lab_data/tests.py
+++ b/ftva_lab_data/tests.py
@@ -37,8 +37,8 @@ class GetFieldValueTests(TestCase):
         self.assertEqual(value, "")
 
 
-class AddEditItemTestCase(TestCase):
-    """Tests for the `add_item` and `edit_item` views."""
+class UserAccessTestCase(TestCase):
+    """Tests expected behavior for different users requesting various views."""
 
     fixtures = ["sample_data.json"]
 
@@ -132,3 +132,14 @@ class AddEditItemTestCase(TestCase):
         # POST request
         response = self.client.post(url, self.test_form_data)
         self.assertEqual(response.status_code, 403)
+
+    def test_anonymous_user_is_redirected_to_login_page(self):
+        """Asserts that an anonymous user (i.e. not logged in)
+        is redirected to login page when trying to GET the base path.
+        """
+        url = "/"
+
+        # GET request
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("/accounts/login/", response.url)

--- a/ftva_lab_data/views.py
+++ b/ftva_lab_data/views.py
@@ -1,5 +1,6 @@
 from django.shortcuts import render, redirect
 from django.contrib import messages
+from django.contrib.auth.decorators import permission_required
 from django.db.models import Q
 from django.core.paginator import Paginator
 from django.http import HttpRequest, HttpResponse
@@ -13,6 +14,10 @@ from .table_config import COLUMNS
 from .views_utils import get_field_value
 
 
+@permission_required(
+    "ftva_lab_data.add_sheetimport",
+    raise_exception=True,
+)
 def add_item(request):
     # context values to be passed to the add_edit_item template
     add_item_context = {
@@ -37,6 +42,10 @@ def add_item(request):
         return render(request, "add_edit_item.html", add_item_context)
 
 
+@permission_required(
+    "ftva_lab_data.change_sheetimport",
+    raise_exception=True,
+)
 def edit_item(request, item_id):
     # Retrieve the item to edit
     item = SheetImport.objects.get(id=item_id)

--- a/ftva_lab_data/views.py
+++ b/ftva_lab_data/views.py
@@ -1,6 +1,6 @@
 from django.shortcuts import render, redirect
 from django.contrib import messages
-from django.contrib.auth.decorators import permission_required
+from django.contrib.auth.decorators import login_required, permission_required
 from django.db.models import Q
 from django.core.paginator import Paginator
 from django.http import HttpRequest, HttpResponse
@@ -14,6 +14,7 @@ from .table_config import COLUMNS
 from .views_utils import get_field_value
 
 
+@login_required
 @permission_required(
     "ftva_lab_data.add_sheetimport",
     raise_exception=True,
@@ -42,6 +43,7 @@ def add_item(request):
         return render(request, "add_edit_item.html", add_item_context)
 
 
+@login_required
 @permission_required(
     "ftva_lab_data.change_sheetimport",
     raise_exception=True,
@@ -70,6 +72,7 @@ def edit_item(request, item_id):
         return render(request, "add_edit_item.html", edit_item_context)
 
 
+@login_required
 def view_item(request, item_id):
     # Retrieve the item to view
     item = SheetImport.objects.get(id=item_id)
@@ -77,6 +80,7 @@ def view_item(request, item_id):
     return render(request, "view_item.html", {"item": item})
 
 
+@login_required
 def search_results(request: HttpRequest) -> HttpResponse:
     users = get_user_model().objects.all().order_by("username")
     return render(
@@ -84,6 +88,7 @@ def search_results(request: HttpRequest) -> HttpResponse:
     )
 
 
+@login_required
 def render_search_results_table(request: HttpRequest) -> HttpResponse:
     """Handles search and pagination of table
 

--- a/project/urls.py
+++ b/project/urls.py
@@ -20,5 +20,6 @@ from django.urls import include, path
 
 urlpatterns = [
     path("", include("ftva_lab_data.urls")),
+    path("accounts/", include("django.contrib.auth.urls")),
     path("admin/", admin.site.urls),
 ]


### PR DESCRIPTION
Implements [SYS-1841](https://uclalibrary.atlassian.net/browse/SYS-1841)

| **Acceptance Criteria** | **Notes** |
|--------|--------|
| ✅ There is an editors groups | The `editors` group is defined in the `groups_and_permissions.json` fixture, with appropriate permissions for adding and editing `SheetImport` objects assigned to it |
| ✅ The group and permission definitions are exported to a fixture | The `groups_and_permissions.json` fixture can be loaded via `python manage.py loaddata groups_and_permissions.json` |
| ✅ All editing functionality is restricted to users in the editors group | This is accomplished using the `@permission_required` decorator on the `add_item` and `edit_item` views |
| ✅ All other functionality within the application is restricted to logged-in users | This is accomplished using the `@login_required` decorator on all views. A template for the login page is also included. |
| ✅ Write a script to create users from [List of Django Users](https://docs.google.com/spreadsheets/d/1EuAZnnNwsqXpa7FH20v4ruzkSntFioBGlyKwMLfbMYw/edit?gid=1630856852#gid=1630856852) | A new management command is defined to handle this. Download a copy of the spreadsheet as an XLSX file, then run `python manage.py create_users_from_sheet -f {SPREADSHEET}.xlsx`.<br /><br />As is, this script creates users, then sets their passwords with `user.set_unusable_password()`. I included an option `--email_users` that I figured could be used later to handle sending users a one-time link to reset their password, when the users are first created. |

### Tests
I wrote 5 tests to confirm that only users with the correct permissions, by way of their inclusion in the `editors` group, can add and edit items.

Run tests with `python manage.py test` after loading the `groups_and_permissions.json` fixture.

### Note about `view_item.html` template
To conditionally render the "Edit This Record" button only for users with suitable permissions, I settled on using `{% if perms.ftva_lab_data.change_sheetimport %}`, as documented [here](https://docs.djangoproject.com/en/5.1/topics/auth/default/#permissions). I figured this was more straightforward than handling the logic in the view or in a helper function.

### Note about `add_edit_item.html` template
Since the add and edit forms are the same, we're using a single template for the two views, `add_item` and `edit_item`. There was an issue accessing the `add_item` URL, because of the Cancel button I had added. I addressed this issue by making the `href` for the link conditionally point to the `view_item` URL if the template is being rendered from the `edit_item` view with an `item` defined in the context, or point to the `search_result` URL otherwise.


[SYS-1841]: https://uclalibrary.atlassian.net/browse/SYS-1841?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ