### PR TITLE
SYS-1864: pagination bug fix

### DIFF
--- a/ftva_lab_data/templates/partials/search_results_table.html
+++ b/ftva_lab_data/templates/partials/search_results_table.html
@@ -40,13 +40,13 @@
 <div class="d-flex justify-content-center align-items-center gap-2">
 
     <button class="btn btn-primary" {% if page_obj.has_previous %}
-        hx-get="{% url 'render_table' %}?page={{ page_obj.previous_page_number }}&search={{ search }}"
+        hx-get="{% url 'render_table' %}?page={{ page_obj.previous_page_number }}&search={{ search }}&search_column={{ search_column }}"
         hx-target="#table-container" {% else %} disabled {% endif %}>Previous</button>
 
     <span>Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}</span>
 
     <button class="btn btn-primary" {% if page_obj.has_next %}
-        hx-get="{% url 'render_table' %}?page={{ page_obj.next_page_number }}&search={{ search }}"
+        hx-get="{% url 'render_table' %}?page={{ page_obj.next_page_number }}&search={{ search }}&search_column={{ search_column }}"
         hx-target="#table-container" {% else %} disabled {% endif %}>Next</button>
 </div>
 

--- a/ftva_lab_data/templates/search_results.html
+++ b/ftva_lab_data/templates/search_results.html
@@ -14,7 +14,7 @@ and replace content of #table-container with result -->
 <form class="d-flex justify-content-end" hx-get="{% url 'render_table' %}" hx-target="#table-container"
     hx-trigger="change from:find select, keyup changed delay:300ms from:find input, clear from:find input">
     <div class="d-flex w-50 gap-2">
-        <select name="column" class="form-select">
+        <select name="search_column" class="form-select">
             <option value="">All columns</option>
             {% for field, label in columns %}
             <option value="{{ field }}">{{ label }}</option>

--- a/ftva_lab_data/tests.py
+++ b/ftva_lab_data/tests.py
@@ -162,11 +162,7 @@ class TablePaginationTestCase(TestCase):
             file_name="unique_file_1", hard_drive_name="test_drive_1", id=100
         )
 
-    def test_search_column_persists_across_pagination(self):
-        """
-        Ensure that the search_column filter is maintained when navigating
-        through paginated results in the search results table.
-        """
+    def test_search_results_with_pagination(self):
         # This search should match the 15 "test_file_" objects created in setUp,
         # but not the "unique_file_1" object.
         search_term = "test"

--- a/ftva_lab_data/views.py
+++ b/ftva_lab_data/views.py
@@ -98,15 +98,15 @@ def render_search_results_table(request: HttpRequest) -> HttpResponse:
     display_fields = [field for field, _ in COLUMNS]
 
     search = request.GET.get("search", "")
-    column = request.GET.get("column", "")
+    search_column = request.GET.get("search_column", "")
     page = request.GET.get("page", 1)
 
     # Only need display fields, plus ID for creating links
     items = SheetImport.objects.only(*display_fields, "id").order_by("id")
     if search:
-        if column and column in display_fields:
+        if search_column and search_column in display_fields:
             # Scoped search to selected column
-            items = items.filter(**{f"{column}__icontains": search})
+            items = items.filter(**{f"{search_column}__icontains": search})
         else:
             # General CTRL-F-style search across all configured fields
             query = Q()  # start with empty Q() object, always True
@@ -138,6 +138,7 @@ def render_search_results_table(request: HttpRequest) -> HttpResponse:
         {
             "page_obj": page_obj,
             "search": search,
+            "search_column": search_column,
             "columns": COLUMNS,
             "rows": rows,
             "users": users,
@@ -161,7 +162,7 @@ def assign_to_user(request: HttpRequest) -> HttpResponse:
     if request.headers.get("HX-Request"):
         # Preserve filters and pagination by copying POST data to GET
         mutable_get = request.GET.copy()
-        for param in ["search", "column", "page"]:
+        for param in ["search", "search_column", "page"]:
             value = request.POST.get(param)
             if value is not None:
                 mutable_get[param] = value

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,0 +1,3 @@
+.checkbox-bold {
+  border: 2px solid var(--bs-gray-600);
+}

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -28,7 +28,7 @@ document.getElementById("assigned-users-form").onsubmit = function (e) {
 
   // Add current filters as hidden inputs
   const search = document.querySelector('input[name="search"]');
-  const column = document.querySelector('select[name="column"]');
+  const search_column = document.querySelector('select[name="search_column"]');
   const page = document.querySelector("#current-page")?.value;
 
   function setOrUpdate(name, value) {
@@ -42,7 +42,11 @@ document.getElementById("assigned-users-form").onsubmit = function (e) {
     el.value = value || "";
   }
   setOrUpdate.call(this, "search", search ? search.value : "");
-  setOrUpdate.call(this, "column", column ? column.value : "");
+  setOrUpdate.call(
+    this,
+    "search_column",
+    search_column ? search_column.value : ""
+  );
   setOrUpdate.call(this, "page", page || "");
 };
 


### PR DESCRIPTION
Fixes [SYS-1864](https://uclalibrary.atlassian.net/browse/SYS-1846)

The bulk of this fix is in lines 43 and 49 of `search_results_table.html`, and line 141 of `views.py`. These changes allow the pagination buttons to pass the name of the column to be searched, as well as the search term and page number.

To test in browser, attempt to replicate the scenario [described in the ticket](https://uclalibrary.atlassian.net/browse/SYS-1846) (search in a column, page back and forth) and observe that the results do not change.

There is a new test case here, which does usefully test search results split across two pages. However, it does not simulate the results of actually clicking on the buttons in the UI - instead, requests with specific parameter values are sent manually. So this test doesn't actually correspond to the bug that was fixed here. If we want to test the actual button-click experience, I'm pretty sure this could be done with `BeautifulSoup` to get URL from the button. Let me know if you think this would be worth it.

I also renamed the variable `column` to `search_column` in templates, views, and JS to reduce (my own) confusion with the unrelated `COLUMNS`.

And finally, I included the new custom CSS file that should have been done with SYS-1842. Checkboxes should now be properly outlined.