### PR TITLE
SYS-1847: Add navbar

### DIFF
--- a/ftva_lab_data/templates/base.html
+++ b/ftva_lab_data/templates/base.html
@@ -16,12 +16,14 @@
     <!-- HTMX -->
     <script src="{% static 'js/htmx-v1.9.12.min.js' %}" defer></script>
     <!-- Custom CSS -->
-    <link rel="stylesheet" type="text/css" href="{% static 'css/style.css' %}"/>
+    <link rel="stylesheet" type="text/css" href="{% static 'css/style.css' %}" />
 </head>
 
 <body class="container-md h-100 d-flex flex-column gap-2">
     <header class="flex-shrink-0">
-        <!-- TODO: add navbar -->
+        {% if not request.resolver_match.view_name == 'login' %}
+        {% include 'partials/navbar.html' %}
+        {% endif %}
     </header>
 
     <main class="flex-grow-1">

--- a/ftva_lab_data/templates/partials/navbar.html
+++ b/ftva_lab_data/templates/partials/navbar.html
@@ -1,0 +1,48 @@
+{% load static %}
+{% load django_bootstrap5 %}
+
+<nav class="navbar navbar-expand-lg p-2">
+    <div class="container-fluid">
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent">
+            <span class="navbar-toggler-icon"></span>
+        </button>
+
+        <div class="collapse navbar-collapse" id="navbarSupportedContent">
+            <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+                <li class="nav-item">
+                    <a class="nav-link active" href="{% url 'search_results' %}">Home</a>
+                </li>
+
+                {% if perms.ftva_lab_data.change_sheetimport %}
+                <li class="nav-item">
+                    <a class="nav-link" href="{% url 'add_item' %}">Add Item</a>
+                </li>
+                {% endif %}
+            </ul>
+
+            <div class="nav-item dropdown">
+                <a class="nav-link dropdown-toggle" data-bs-toggle="dropdown" role="button">Account</a>
+
+                <ul class="dropdown-menu dropdown-menu-md-end">
+                    {% if user.is_staff %}
+                    <li>
+                        <a class="dropdown-item" href="/admin/">Admin Console</a>
+                    </li>
+                    {% endif %}
+                    <li>
+                        <a class="dropdown-item" href="{% url 'password_change' %}">Change Password</a>
+                    </li>
+                    <li>
+                        <hr class="dropdown-divider">
+                    </li>
+                    <li>
+                        <form class="d-inline" method="post" action="{% url 'logout' %}">
+                            {% csrf_token %}
+                            <button type="submit" class="btn btn-default dropdown-item">Logout</button>
+                        </form>
+                    </li>
+                </ul>
+            </div>
+        </div>
+    </div>
+</nav>


### PR DESCRIPTION
Implements [SYS-1847](https://uclalibrary.atlassian.net/browse/SYS-1847)

**Acceptance Criteria**
- ✅ A navigation bar is added to the top of every page, via base.html
- ✅ All authorized functions are available via the navigation bar, including logout
  - All users see a link to change password and logout in the navbar dropdown
  - For users with built-in staff assignment via Django admin, the navbar dropdown will show a link to the admin console, in addition to the change password and logout links
  - Users in the `editors` group also see link to the `add_item` view in the navbar
- ✅ This should be similar to what we’ve used before in other Django projects.

**Tests**
FWIW, all automated tests still pass after these changes. Manual testing looks good to me.