### PR TITLE
SYS-1843: Hide empty fields on View Item screen

### DIFF
--- a/ftva_lab_data/templates/view_item.html
+++ b/ftva_lab_data/templates/view_item.html
@@ -79,7 +79,7 @@
                             <p class="card-text"><strong>{{ header }}:</strong> {{ data }}</p>
                         {% endif %}
                         <!--- New div after 18 rows of data-->
-                        {% if forloop.counter == 18 %}
+                        {% if forloop.counter == 19 %}
                             </div>
                             <div class="col">
                         {% endif %}

--- a/ftva_lab_data/templates/view_item.html
+++ b/ftva_lab_data/templates/view_item.html
@@ -10,8 +10,9 @@
 
 <div class="container">
     <h1>Item details</h1>
-    <p class="fs-5">{% if item.file_name %} File: {{ item.file_name }} {% endif %}</p>
-    <p class="fs-5">{% if item.title %} (Title: {{ item.title }}) {% endif %}</p>
+
+    <p class="fs-5">{% if header_info.file_name %} File: {{ header_info.file_name }} {% endif %}</p>
+    <p class="fs-5">{% if header_info.title %} (Title: {{ header_info.title }}) {% endif %}</p>
 
     <!-- Buttons -->
     <div class="d-flex justify-content-between mb-3">
@@ -19,7 +20,7 @@
             <button id="toggle-advanced-fields" class="btn btn-secondary" type="button"
                 hx-on:click="toggleAdvancedFields(this)">Show Advanced Fields</button>
             {% if perms.ftva_lab_data.change_sheetimport %}
-            <a class="btn btn-primary" href="{% url 'edit_item' item.id %}">Edit This Record</a>
+            <a class="btn btn-primary" href="{% url 'edit_item' header_info.id %}">Edit This Record</a>
             {% endif %}
         </div>
 
@@ -32,10 +33,11 @@
             <div class="card">
                 <div class="card-body">
                     <h5 class="card-title">Storage Information </h5>
-                    <p class="card-text"><strong>Hard Drive Name:</strong> {{ item.hard_drive_name }}</p>
-                    <p class="card-text"><strong>DML LTO Tape ID:</strong> {{ item.dml_lto_tape_id }}</p>
-                    <p class="card-text"><strong>ARSC LTO Tape ID:</strong> {{ item.arsc_lto_tape_id }}</p>
-                    <p class="card-text"><strong>Hard Drive Barcode ID:</strong> {{ item.hard_drive_barcode_id }}</p>
+                    {% for header, data in storage_info.items %}
+                        {% if data %}
+                            <p class="card-text"><strong>{{ header }}:</strong> {{ data }}</p>
+                        {% endif %}
+                    {% endfor %}
                 </div>
             </div>
         </div>
@@ -44,9 +46,11 @@
             <div class="card">
                 <div class="card-body">
                     <h5 class="card-title">File Information</h5>
-                    <p class="card-text"><strong>File Folder Name:</strong> {{ item.file_folder_name }}</p>
-                    <p class="card-text"><strong>Sub Folder Name:</strong> {{ item.sub_folder_name }}</p>
-                    <p class="card-text"><strong>File Name:</strong> {{ item.file_name }}</p>
+                    {% for header, data in file_info.items %}
+                        {% if data %}
+                            <p class="card-text"><strong>{{ header }}:</strong> {{ data }}</p>
+                        {% endif %}
+                    {% endfor %}    
                 </div>
             </div>
         </div>
@@ -55,11 +59,11 @@
             <div class="card">
                 <div class="card-body">
                     <h5 class="card-title">Inventory Information</h5>
-                    <p class="card-text"><strong>Inventory Number:</strong> {{ item.inventory_number }}</p>
-                    <p class="card-text"><strong>Source Inventory Number:</strong> {{ item.source_inventory_number }}
-                    </p>
-                    <p class="card-text"><strong>Source Barcode:</strong> {{ item.source_barcode }}</p>
-                    <p class="card-text"><strong>Title:</strong> {{ item.title }}</p>
+                    {% for header, data in inventory_info.items %}
+                        {% if data %}
+                            <p class="card-text"><strong>{{ header }}:</strong> {{ data }}</p>
+                        {% endif %}
+                    {% endfor %}
                 </div>
             </div>
         </div>
@@ -70,54 +74,16 @@
         <div class="card">
             <div class="card-body row">
                 <div class="col">
-                    <p class="card-text"><strong>Source Type:</strong> {{ item.source_type }}</p>
-                    <p class="card-text"><strong>Resolution:</strong> {{ item.resolution }}</p>
-                    <p class="card-text"><strong>Compression:</strong> {{ item.compression }}</p>
-                    <p class="card-text"><strong>File Format:</strong> {{ item.file_format }}</p>
-                    <p class="card-text"><strong>File Size:</strong> {{ item.file_size }}</p>
-                    <p class="card-text"><strong>Frame Rate:</strong> {{ item.frame_rate }}</p>
-                    <p class="card-text"><strong>Total Running Time:</strong> {{ item.total_running_time }}</p>
-                    <p class="card-text"><strong>Source Frame Rate:</strong> {{ item.source_frame_rate }}</p>
-                    <p class="card-text"><strong>Aspect Ratio:</strong> {{ item.aspect_ratio }}</p>
-                    <p class="card-text"><strong>Color Bit Depth:</strong> {{ item.color_bit_depth }}</p>
-                    <p class="card-text"><strong>Color Type:</strong> {{ item.color_type }}</p>
-                    <p class="card-text"><strong>Frame Layout:</strong> {{ item.frame_layout }}</p>
-                    <p class="card-text"><strong>Sample Structure:</strong> {{ item.sample_structure }}</p>
-                    <p class="card-text"><strong>Sample Rate:</strong> {{ item.sample_rate }}</p>
-                    <p class="card-text"><strong>Capture Device Make and Model:</strong>
-                        {{ item.capture_device_make_and_model }}</p>
-                    <p class="card-text"><strong>Capture Device Settings:</strong> {{ item.capture_device_settings }}
-                    </p>
-                    <p class="card-text"><strong>Date Capture Completed:</strong> {{ item.date_capture_completed }}</p>
-                    <p class="card-text"><strong>Video Edit Software and Settings:</strong>
-                        {{ item.video_edit_software_and_settings }}</p>
-                    <p class="card-text"><strong>Date Edit Completed:</strong> {{ item.date_edit_completed }}</p>
-                </div>
-                <div class="col">
-                    <p class="card-text"><strong>Color Grading Software:</strong> {{ item.color_grading_software }}</p>
-                    <p class="card-text"><strong>Color Grading Settings:</strong> {{ item.color_grading_settings }}</p>
-                    <p class="card-text"><strong>Audio File Format:</strong> {{ item.audio_file_format }}</p>
-                    <p class="card-text"><strong>Date Audio Edit Completed:</strong>
-                        {{ item.date_audio_edit_completed }}
-                    </p>
-                    <p class="card-text"><strong>Remaster Platform:</strong> {{ item.remaster_platform }}</p>
-                    <p class="card-text"><strong>Remaster Software:</strong> {{ item.remaster_software }}</p>
-                    <p class="card-text"><strong>Remaster Settings:</strong> {{ item.remaster_settings }}</p>
-                    <p class="card-text"><strong>Date Remaster Completed:</strong> {{ item.date_remaster_completed }}
-                    </p>
-                    <p class="card-text"><strong>Subtitles:</strong> {{ item.subtitles }}</p>
-                    <p class="card-text"><strong>Watermark Type:</strong> {{ item.watermark_type }}</p>
-                    <p class="card-text"><strong>Security Data/Encrypted:</strong> {{ item.security_data_encrypted }}
-                    </p>
-                    <p class="card-text"><strong>Migration or Preservation Record:</strong>
-                        {{ item.migration_or_preservation_record }}</p>
-                    <p class="card-text"><strong>Hard Drive Location:</strong> {{ item.hard_drive_location }}</p>
-                    <p class="card-text"><strong>Date Job Started:</strong> {{ item.date_job_started }}</p>
-                    <p class="card-text"><strong>Date Job Completed:</strong> {{ item.date_job_completed }}</p>
-                    <p class="card-text"><strong>General Entry Cataloged By:</strong>
-                        {{ item.general_entry_cataloged_by }}
-                    </p>
-                    <p class="card-text"><strong>Notes:</strong> {{ item.notes }}</p>
+                    {% for header, data in advanced_info.items %}
+                        {% if data %}
+                            <p class="card-text"><strong>{{ header }}:</strong> {{ data }}</p>
+                        {% endif %}
+                        <!--- New div after 18 rows of data-->
+                        {% if forloop.counter == 18 %}
+                            </div>
+                            <div class="col">
+                        {% endif %}
+                    {% endfor %}
                 </div>
             </div>
         </div>

--- a/ftva_lab_data/tests.py
+++ b/ftva_lab_data/tests.py
@@ -3,7 +3,7 @@ from ftva_lab_data.models import SheetImport
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import User, Group
 from django.urls import reverse
-from ftva_lab_data.views_utils import get_field_value
+from ftva_lab_data.views_utils import get_field_value, get_item_display_dicts
 
 
 class GetFieldValueTests(TestCase):
@@ -213,3 +213,34 @@ class HistoryModelTestCase(TestCase):
         # Get the earliest version and confirm its title is the original value.
         previous_obj = obj.history.earliest()
         self.assertEqual(previous_obj.title, old_value)
+
+class ItemDisplayTestCase(TestCase):
+    """Tests the get_item_display_dicts function."""
+
+    def setUp(self):
+        # Create a test SheetImport object
+        self.item = SheetImport.objects.create(
+            file_name="test_file",
+            hard_drive_name="test_drive",
+            file_folder_name="test_folder",
+            inventory_number="INV001",
+            resolution="1920x1080",
+        )
+
+    def test_get_item_display_dicts(self):
+        display_dicts = get_item_display_dicts(self.item)
+        # Check that the returned dictionary has the expected structure
+        self.assertIn("header_info", display_dicts)
+        self.assertIn("storage_info", display_dicts)
+        self.assertIn("file_info", display_dicts)
+        self.assertIn("inventory_info", display_dicts)
+        self.assertIn("advanced_info", display_dicts)
+        # Check that the values in the dictionaries match the item attributes
+        self.assertEqual(display_dicts["header_info"]["File Name"], "test_file")
+        self.assertEqual(display_dicts["storage_info"]["Hard Drive Name"], "test_drive")
+        self.assertEqual(display_dicts["file_info"]["File/Folder Name"], "test_folder")
+        self.assertEqual(display_dicts["inventory_info"]["Inventory Number"], "INV001")
+        self.assertEqual(display_dicts["advanced_info"]["Resolution"], "1920x1080")
+        # Check that empty fields are handled correctly (i.e. are in the dict as empty strings)
+        self.assertEqual(display_dicts["storage_info"].get("DML LTO Tape ID"), "")
+        

--- a/ftva_lab_data/tests.py
+++ b/ftva_lab_data/tests.py
@@ -243,4 +243,3 @@ class ItemDisplayTestCase(TestCase):
         self.assertEqual(display_dicts["advanced_info"]["Resolution"], "1920x1080")
         # Check that empty fields are handled correctly (i.e. are in the dict as empty strings)
         self.assertEqual(display_dicts["storage_info"].get("DML LTO Tape ID"), "")
-        

--- a/ftva_lab_data/tests.py
+++ b/ftva_lab_data/tests.py
@@ -214,6 +214,7 @@ class HistoryModelTestCase(TestCase):
         previous_obj = obj.history.earliest()
         self.assertEqual(previous_obj.title, old_value)
 
+
 class ItemDisplayTestCase(TestCase):
     """Tests the get_item_display_dicts function."""
 

--- a/ftva_lab_data/views.py
+++ b/ftva_lab_data/views.py
@@ -11,7 +11,7 @@ from django.template.loader import render_to_string
 from .forms import ItemForm
 from .models import SheetImport
 from .table_config import COLUMNS
-from .views_utils import get_field_value
+from .views_utils import get_field_value, get_item_display_dicts
 
 
 @login_required
@@ -64,7 +64,7 @@ def edit_item(request, item_id):
         if form.is_valid():
             form.save()
             messages.success(request, "Item updated successfully!")
-            return render(request, "view_item.html", {"item": item})
+            return render(request, "view_item.html", get_item_display_dicts(item))
         else:
             messages.error(request, "Please correct the errors below.")
             return render(request, "add_edit_item.html", edit_item_context)
@@ -76,8 +76,14 @@ def edit_item(request, item_id):
 def view_item(request, item_id):
     # Retrieve the item to view
     item = SheetImport.objects.get(id=item_id)
+    # For easier parsing in the template, separate attributes into dictionaries
+    display_dicts = get_item_display_dicts(item)
 
-    return render(request, "view_item.html", {"item": item})
+    return render(
+        request,
+        "view_item.html",
+        display_dicts 
+    )
 
 
 @login_required

--- a/ftva_lab_data/views_utils.py
+++ b/ftva_lab_data/views_utils.py
@@ -1,5 +1,6 @@
 from typing import Any
 from django.db import models
+from .models import SheetImport
 
 
 # Recursive implementation adapted from:
@@ -26,3 +27,75 @@ def get_field_value(obj: models.Model, field: str) -> Any:
         first_field = fields[0]
         remaining_fields = "__".join(fields[1:])
         return get_field_value(getattr(obj, first_field), remaining_fields)
+
+def get_item_display_dicts(item: SheetImport) -> dict[str, Any]:
+    """Returns a dictionary of dictionaries. Each top-level dict represents a display section for
+    the view_item.html template."""
+    header_info = {
+        "File Name": item.file_name,
+        "Title": item.title,
+        "id": item.id,
+    }
+    storage_info = {
+        "Hard Drive Name": item.hard_drive_name,
+        "DML LTO Tape ID": item.dml_lto_tape_id,
+        "ARSC LTO Tape ID": item.arsc_lto_tape_id,
+        "Hard Drive Barcode ID": item.hard_drive_barcode_id,
+    }
+    file_info = {
+        "File/Folder Name": item.file_folder_name,
+        "Sub-Folder Name": item.sub_folder_name,
+        "File Name": item.file_name,
+    }
+    inventory_info = {
+        "Inventory Number": item.inventory_number,
+        "Source Inventory Number": item.source_inventory_number,
+        "Source Barcode": item.source_barcode,
+        "Title": item.title,
+    }
+    advanced_info = {
+        "Job Number": item.job_number,
+        "Source Type": item.source_type,
+        "Resolution": item.resolution,
+        "Compression": item.compression,
+        "File Format": item.file_format,
+        "File Size": item.file_size,
+        "Frame Rate": item.frame_rate,
+        "Total Running Time": item.total_running_time,
+        "Source Frame Rate": item.source_frame_rate,
+        "Aspect Ratio": item.aspect_ratio,
+        "Color Bit Depth": item.color_bit_depth,
+        "Color Type": item.color_type,
+        "Frame Layout": item.frame_layout,
+        "Sample Structure": item.sample_structure,
+        "Sample Rate": item.sample_rate,
+        "Capture Device Make and Model": item.capture_device_make_and_model,
+        "Capture Device Settings": item.capture_device_settings,
+        "Date Capture Completed": item.date_capture_completed,
+        "Video Edit Software and Settings": item.video_edit_software_and_settings,
+        "Date Edit Completed": item.date_edit_completed,
+        "Color Grading Software": item.color_grading_software,
+        "Color Grading Settings": item.color_grading_settings,
+        "Audio File Format": item.audio_file_format,
+        "Date Audio Edit Completed": item.date_audio_edit_completed,
+        "Remaster Platform": item.remaster_platform,
+        "Remaster Software": item.remaster_software,
+        "Remaster Settings": item.remaster_settings,
+        "Date Remaster Completed": item.date_remaster_completed,
+        "Subtitles": item.subtitles,
+        "Watermark Type": item.watermark_type,
+        "Security Data Encrypted": item.security_data_encrypted,
+        "Migration or Preservation Record": item.migration_or_preservation_record,
+        "Hard Drive Location": item.hard_drive_location,
+        "Date Job Started": item.date_job_started,
+        "Date Job Completed": item.date_job_completed,
+        "General Entry Cataloged By": item.general_entry_cataloged_by,
+        "Notes": item.notes,
+    }
+    return {
+        "header_info": header_info,
+        "storage_info": storage_info,
+        "file_info": file_info,
+        "inventory_info": inventory_info,
+        "advanced_info": advanced_info,
+    }

--- a/ftva_lab_data/views_utils.py
+++ b/ftva_lab_data/views_utils.py
@@ -99,4 +99,3 @@ def get_item_display_dicts(item: SheetImport) -> dict[str, Any]:
         "inventory_info": inventory_info,
         "advanced_info": advanced_info,
     }
-    

--- a/ftva_lab_data/views_utils.py
+++ b/ftva_lab_data/views_utils.py
@@ -99,3 +99,4 @@ def get_item_display_dicts(item: SheetImport) -> dict[str, Any]:
         "inventory_info": inventory_info,
         "advanced_info": advanced_info,
     }
+    

--- a/ftva_lab_data/views_utils.py
+++ b/ftva_lab_data/views_utils.py
@@ -28,6 +28,7 @@ def get_field_value(obj: models.Model, field: str) -> Any:
         remaining_fields = "__".join(fields[1:])
         return get_field_value(getattr(obj, first_field), remaining_fields)
 
+
 def get_item_display_dicts(item: SheetImport) -> dict[str, Any]:
     """Returns a dictionary of dictionaries. Each top-level dict represents a display section for
     the view_item.html template."""


### PR DESCRIPTION
Implements [SYS-1843](https://uclalibrary.atlassian.net/browse/SYS-1843)

Updates views and templates to hide fields with no values on the "View Item" display, as in the below screenshot.

<img width="1281" alt="image" src="https://github.com/user-attachments/assets/66c922bd-44ef-4991-a4c8-b48e97a79f90" />

To support this, the `view_item.html` template now expects as context a collection of dicts corresponding to different areas of the display: `header_info`, `storage_info`, `file_info`, `inventory_info`, and `advanced_info`. These dicts are created by the new `get_item_display_dicts()` function in `views_utils.py`. This PR includes a simple test for this function.

[SYS-1843]: https://uclalibrary.atlassian.net/browse/SYS-1843?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ