### PR TITLE
SYS-1854: fix search result column widths, plus other styling improvements

### DIFF
--- a/docker_scripts/entrypoint.sh
+++ b/docker_scripts/entrypoint.sh
@@ -32,7 +32,7 @@ if [ "$DJANGO_RUN_ENV" = "dev" ]; then
   python manage.py createsuperuser --no-input
 
   # Load fixtures, only in dev environment.
-  python manage.py loaddata sample_data.json groups_and_permissions.json
+  python manage.py loaddata groups_and_permissions.json item_statuses.json
 fi
 
 if [ "$DJANGO_RUN_ENV" = "dev" ]; then

--- a/ftva_lab_data/templates/base.html
+++ b/ftva_lab_data/templates/base.html
@@ -19,7 +19,7 @@
     <link rel="stylesheet" type="text/css" href="{% static 'css/style.css' %}" />
 </head>
 
-<body class="container-md h-100 d-flex flex-column gap-2">
+<body class="container-fluid h-100 d-flex flex-column gap-2">
     <header class="flex-shrink-0">
         {% if not request.resolver_match.view_name == 'login' %}
         {% include 'partials/navbar.html' %}

--- a/ftva_lab_data/templates/partials/search_results_table.html
+++ b/ftva_lab_data/templates/partials/search_results_table.html
@@ -25,9 +25,9 @@
         <!--Source inv no.-->
         <col style="width: 10%;">
         <!--Status-->
-        <col style="width: 15%;">
+        <col style="width: 16%;">
         <!--Assigned user-->
-        <col style="width: 10%;">
+        <col style="width: 9%;">
         <!--View link-->
         <col style="width: 5%;">
         <!--Checkbox for assigning-->
@@ -51,18 +51,16 @@
     <tbody>
         {% for row in rows %}
         <tr>
-            {% for field, value in row.data.items %}     
-                {% if field == "status" %}
+            {% for field, value in row.data.items %}
                 <td>
-                    {% for status in value %}
-                        <span class="badge rounded-pill bg-info text-dark m-1">{{ status }}</span>
-                    {% endfor %}
-                </td>
-                {% else %}
-                <td class="nowrap">
-                    {{ value }}
-                </td>
-                {% endif %}              
+                    {% if field == "status" %}
+                        {% for status in value %}
+                            <span class="badge rounded-pill bg-info text-dark m-1">{{ status }}</span>
+                        {% endfor %}
+                    {% else %}
+                        {{ value }}
+                    {% endif %}     
+                </td>         
             {% endfor %}
             <td>
                 <a class="btn btn-link btn-sm" href="{% url 'view_item' row.id %}">View</a>

--- a/ftva_lab_data/templates/partials/search_results_table.html
+++ b/ftva_lab_data/templates/partials/search_results_table.html
@@ -1,12 +1,46 @@
-<table class="table table-hover">
+<div class="d-flex justify-content-center align-items-center gap-2">
+
+    <button class="btn btn-primary" {% if page_obj.has_previous %}
+        hx-get="{% url 'render_table' %}?page={{ page_obj.previous_page_number }}&search={{ search }}&search_column={{ search_column }}"
+        hx-target="#table-container" {% else %} disabled {% endif %}>Previous</button>
+
+    <span>Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}</span>
+
+    <button class="btn btn-primary" {% if page_obj.has_next %}
+        hx-get="{% url 'render_table' %}?page={{ page_obj.next_page_number }}&search={{ search }}&search_column={{ search_column }}"
+        hx-target="#table-container" {% else %} disabled {% endif %}>Next</button>
+</div>
+
+
+<table class="table table-hover" style="table-layout: fixed;">
+    <colgroup>
+        <!--Hard drive-->
+        <col style="width: 10%;">
+        <!--File folder-->
+        <col style="width: 10%;">
+        <!--Sub-folder-->
+        <col style="width: 10%;">
+        <!--Filename-->
+        <col style="width: 25%;">
+        <!--Source inv no.-->
+        <col style="width: 10%;">
+        <!--Status-->
+        <col style="width: 15%;">
+        <!--Assigned user-->
+        <col style="width: 10%;">
+        <!--View link-->
+        <col style="width: 5%;">
+        <!--Checkbox for assigning-->
+        <col style="width: 5%;">
+    </colgroup>
     <thead>
         <tr>
             {% for _, label in columns %}
             <th>{{ label }}</th>
             {% endfor %}
+            <!--Empty <th> for View link-->
             <th></th>
-            <th class="text-center">
-
+            <th class ="text-center">
                 Assign
                 <div class="form-check justify-content-center m-0" style="display: flex;" title="Select all items on this page">
                     <input type="checkbox" class="form-check-input checkbox-bold" id="select-all-checkbox">
@@ -17,16 +51,18 @@
     <tbody>
         {% for row in rows %}
         <tr>
-            {% for field, value in row.data.items %}
+            {% for field, value in row.data.items %}     
+                {% if field == "status" %}
                 <td>
-                    {% if field == "status" %}
-                        {% for status in value %}
-                            <span class="badge rounded-pill bg-info text-dark m-1">{{ status }}</span>
-                        {% endfor %}
-                    {% else %}
-                        {{ value }}
-                    {% endif %}
+                    {% for status in value %}
+                        <span class="badge rounded-pill bg-info text-dark m-1">{{ status }}</span>
+                    {% endfor %}
                 </td>
+                {% else %}
+                <td class="nowrap">
+                    {{ value }}
+                </td>
+                {% endif %}              
             {% endfor %}
             <td>
                 <a class="btn btn-link btn-sm" href="{% url 'view_item' row.id %}">View</a>
@@ -39,7 +75,7 @@
         </tr>
         {% empty %}
         <tr>
-            <td class="text-center" colspan="{{ columns|length|add:1 }}">No results found.</td>
+            <td class="text-left" colspan="{{ columns|length|add:1 }}">No results found.</td>
         </tr>
         {% endfor %}
     </tbody>

--- a/ftva_lab_data/templates/search_results.html
+++ b/ftva_lab_data/templates/search_results.html
@@ -5,23 +5,25 @@
 <div id="messages">
     {% include "partials/messages.html" %}
 </div>
+<div class="w-75 mx-auto">
+    <h1>Items</h1>
+</div>
 
-<h1>Items</h1>
+<div class="d-flex align-items-stretch gap-2 mb-3 w-75 mx-auto">
 
-<!-- HTMX will listen for triggers from enclosed controls,
-then issue GET requests to 'render_table' URL
-and replace content of #table-container with result -->
-<form class="d-flex justify-content-end" hx-get="{% url 'render_table' %}" hx-target="#table-container"
-    hx-trigger="change from:find select, keyup changed delay:300ms from:find input, clear from:find input">
-    <div class="d-flex w-50 gap-2">
-        <select name="search_column" class="form-select">
+    <!-- HTMX will listen for triggers from enclosed controls,
+    then issue GET requests to 'render_table' URL
+    and replace content of #table-container with result -->
+    <form class="d-flex gap-2 align-items-stretch w-50" hx-get="{% url 'render_table' %}" hx-target="#table-container"
+        hx-trigger="change from:find select, keyup changed delay:300ms from:find input, clear from:find input">
+        <select name="search_column" class="form-select form-select-sm">
             <option value="">All columns</option>
             {% for field, label in columns %}
             <option value="{{ field }}">{{ label }}</option>
             {% endfor %}
         </select>
-        <div class="input-group">
-            <input id="search-input" class="form-control" type="text" name="search" placeholder="Enter search term...">
+        <div class="input-group input-group-sm">
+            <input id="search-input" class="form-control form-control-sm" type="text" name="search" placeholder="Enter search term...">
             <span class="input-group-text">
                 <button class="btn p-0 border-0" type="button" hx-on:click="clearSearchInput()">
                     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor"
@@ -33,29 +35,25 @@ and replace content of #table-container with result -->
                 </button>
             </span>
         </div>
-    </div>
-</form>
+    </form>
 
-<form id="assigned-users-form" method="post" hx-post="{% url 'assign_to_user' %}" hx-target="#table-container" class="d-flex justify-content-end">
-    {% csrf_token %}
-    <div class="d-flex w-50 gap-2 input-group">
-        <select name="user_id" class="form-select" required>
+    <form id="assigned-users-form" method="post" hx-post="{% url 'assign_to_user' %}" hx-target="#table-container" class="d-flex gap-2 align-items-stretch w-50">
+        {% csrf_token %}
+        <select name="user_id" class="form-select form-select-sm" required>
             <option value="">Assign to...</option>
             <option value="__unassign__">Unassign</option>
             {% for user in users %}
             <option value="{{ user.id }}">{{ user.username }}</option>
             {% endfor %}
         </select>
-    <button type="submit" class="btn btn-primary">Assign Selected</button>
-
-    </div>
-</form>
-
+        <button type="submit" class="btn btn-sm btn-primary">Assign Selected</button>
+    </form>
+</div> 
 
 
 <!-- On page load, HTMX triggers GET request to 'render_table'
 and inserts it within div -->
-<div id="table-container" class="p-2" hx-get="{% url 'render_table' %}" hx-trigger="load"></div>
+<div id="table-container" class="table-responsive container-fluid p-4" hx-get="{% url 'render_table' %}" hx-trigger="load"></div>
 
 
 {% endblock %}

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -4,11 +4,4 @@
 
 #table-container td {
     word-break: break-all;
-    overflow: hidden;
-    text-overflow: ellipsis;
-}
-
-
-#table-container .no-wrap {
-    white-space: nowrap;
 }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,3 +1,14 @@
 .checkbox-bold {
   border: 2px solid var(--bs-gray-600);
 }
+
+#table-container td {
+    word-break: break-all;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+
+#table-container .no-wrap {
+    white-space: nowrap;
+}


### PR DESCRIPTION
Fixes [SYS-1854](https://uclalibrary.atlassian.net/browse/SYS-1854)

Through application of Bootstrap CSS classes and one small custom CSS change, several updates to the search results screen:

* Each column now has a fixed width as a percentage of the total table width. Column sizes should not change as filters are changed and pages are navigated.
    * Instead of truncating, I opted to wrap text. I noticed that a number of filenames have distinguishing features only near the end of the name (e.g. "M190540_HTD10_104_R1191_MonroeSitsOutMillersTrial_**CaptureFiles_HD_ProRes4444**" vs. "M190540_HTD10_104_R1191_MonroeSitsOutMillersTrial_**Final_HD_ProRes4444**", which might be hidden behind truncation at smaller screen sizes. 
* Left and right margins on the table are reduced.
* Navigation buttons are available at the top and bottom of search results.
* Search and user assignment forms are combined into a single line, with width set to 75% of the page.

I tested these changes on screen sizes from my small laptop (1425 px wide) to my large monitor (1905 px wide).

[SYS-1854]: https://uclalibrary.atlassian.net/browse/SYS-1854?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ