### PR TITLE
SYS-1858: fix Assign checkbox alignment

### DIFF
--- a/ftva_lab_data/templates/partials/search_results_table.html
+++ b/ftva_lab_data/templates/partials/search_results_table.html
@@ -65,7 +65,7 @@
             <td>
                 <a class="btn btn-link btn-sm" href="{% url 'view_item' row.id %}">View</a>
             </td>
-            <td class="align-middle">
+            <td class="align-top">
                 <div class="form-check justify-content-center m-0" style="display: flex;">
                     <input type="checkbox" class="form-check-input row-checkbox checkbox-bold" name="selected_ids" value="{{ row.id }}">
                 </div>


### PR DESCRIPTION
Fixes [SYS-1858](https://uclalibrary.atlassian.net/browse/SYS-1858)

Fixes the bootstrap CSS class on the Assign column of the search results display. Checkboxes should now be top-aligned, matching other data elements.

<img width="1388" alt="image" src="https://github.com/user-attachments/assets/55e140b9-0c49-4ebb-bae1-1148c0d9cfe0" />


[SYS-1858]: https://uclalibrary.atlassian.net/browse/SYS-1858?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ