### PR TITLE
SYS-1864: Add support for full user names

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,8 +14,11 @@
 							"editor.formatOnSave": true,
 							"python.analysis.typeCheckingMode": "standard",
 							"python.analysis.diagnosticSeverityOverrides": {
-								// Disable errors for Django's dynamic "id" model attributes
-								"reportAttributeAccessIssue": "information"
+								// Downgrade errors for Django's dynamic "id" model attributes
+								"reportAttributeAccessIssue": "information",
+								// Downgrade errors when accessing methods on Django's 
+								// related model attributes, like obj.assigned_user.get_full_name()
+								"reportOptionalMemberAccess": "information"
 							},
 							"python.editor.defaultFormatter": "ms-python.black-formatter",
 					"flake8.args": [

--- a/.gitignore
+++ b/.gitignore
@@ -181,3 +181,6 @@ cython_debug/
 
 # Local static files collected when testing gunicorn and whitenoise
 staticfiles/
+
+# Data files
+*.xlsx

--- a/charts/prod-ftvalabdata-values.yaml
+++ b/charts/prod-ftvalabdata-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/ftva-lab-data
-  tag: v0.9.0
+  tag: v0.9.1
   pullPolicy: Always
 
 nameOverride: ""

--- a/ftva_lab_data/models.py
+++ b/ftva_lab_data/models.py
@@ -78,6 +78,10 @@ class SheetImport(models.Model):
     def __str__(self):
         return f"id: {self.id} --- file: {self.file_name} --- title: {self.title}"
 
+    @property
+    def assigned_user_full_name(self):
+        return self.assigned_user.get_full_name()
+
     class Meta:
         permissions = [("assign_user", "Can assign user to SheetImport")]
 

--- a/ftva_lab_data/table_config.py
+++ b/ftva_lab_data/table_config.py
@@ -8,5 +8,5 @@ COLUMNS = [
     ("file_name", "Filename"),
     ("inventory_number", "Inventory number"),
     ("status", "Status"),
-    ("assigned_user__username", "Assigned user"),
+    ("assigned_user_full_name", "Assigned user"),
 ]

--- a/ftva_lab_data/templates/partials/search_results_table.html
+++ b/ftva_lab_data/templates/partials/search_results_table.html
@@ -57,6 +57,8 @@
                         {% for status in value %}
                             <span class="badge rounded-pill bg-info text-dark m-1">{{ status }}</span>
                         {% endfor %}
+                    {% elif field == "assigned_user_full_name" %}
+                        {{ value }}
                     {% else %}
                         {{ value }}
                     {% endif %}     

--- a/ftva_lab_data/templates/search_results.html
+++ b/ftva_lab_data/templates/search_results.html
@@ -44,7 +44,7 @@
             <option value="">Assign to...</option>
             <option value="__unassign__">Unassign</option>
             {% for user in users %}
-            <option value="{{ user.id }}">{{ user.username }}</option>
+            <option value="{{ user.id }}">{{ user.get_full_name }}</option>
             {% endfor %}
         </select>
         <button type="submit" class="btn btn-sm btn-primary">Assign Selected</button>

--- a/ftva_lab_data/views.py
+++ b/ftva_lab_data/views.py
@@ -151,9 +151,6 @@ def render_search_results_table(request: HttpRequest) -> HttpResponse:
         for item in page_obj.object_list
     ]
 
-    # Get all users for the dropdown in the table
-    users = get_user_model().objects.all().order_by("username")
-
     return render(
         request,
         "partials/search_results_table.html",
@@ -163,7 +160,6 @@ def render_search_results_table(request: HttpRequest) -> HttpResponse:
             "search_column": search_column,
             "columns": COLUMNS,
             "rows": rows,
-            "users": users,
         },
     )
 

--- a/ftva_lab_data/views_utils.py
+++ b/ftva_lab_data/views_utils.py
@@ -59,11 +59,11 @@ def get_item_display_dicts(item: SheetImport) -> dict[str, Any]:
     inventory_info = {
         "Inventory Number": item.inventory_number,
         "Source Barcode": item.source_barcode,
-        "Title": item.title,
         "Notes": item.notes,
     }
     advanced_info = {
         "Source Inventory Number": item.source_inventory_number,
+        "Title": item.title,
         "Job Number": item.job_number,
         "Source Type": item.source_type,
         "Resolution": item.resolution,

--- a/ftva_lab_data/views_utils.py
+++ b/ftva_lab_data/views_utils.py
@@ -120,7 +120,6 @@ def get_add_edit_item_fields(form: ItemForm) -> dict[str, list[str]]:
         "carrier_b",
         "carrier_b_location",
         "hard_drive_barcode_id",
-        "title",
         "file_folder_name",
         "sub_folder_name",
         "file_name",


### PR DESCRIPTION
Implements [SYS-1864](https://uclalibrary.atlassian.net/browse/SYS-1864).  Version set to `v0.9.1` for deployment.

This PR adds support for displaying and searching full user names, which was a bigger set of changes than I expected:
* Changed the "Assign to..." list of users to display full name instead of username, via built-in `User.get_full_name()`
* Added a calculated property `assigned_user_full_name` to `SheetImport`, to support display of full names for users assigned to those records
* Changed search results template to display the new `assigned_user_full_name`  property
* Changed views and supporting files to search against `assigned_user_full_name`
  * Searches are done against the first name, last name, and username
  * It's not worth the effort to add support for searching full name, in my opinion, but it's possible

Adding this search support led to greater duplication of code.  Searching a single field used the same logic as searching multiple fields, so I refactored that code: a single field is just a list of one field, so I combined the specific and general cases.

The `render_search_results_table` view was doing a little too much, with both the logic for the search and the preparation of data for display.  The search logic is also somewhat complex, and a little fragile, so I wanted it to be testable.  To do this, I pulled the search into a supporting function in `views_utils.get_search_items()`, and wrote enough tests to cover the basic and more complex variations.

Other minor changes:
* I included [SYS-1863](https://uclalibrary.atlassian.net/browse/SYS-1863), moving the Title field from the Basic to Advanced fields for editing, since this was a trivial one-line change.
* Excel files are now ignored for source control.
* I updated `devcontainer.json` to downgrade `reportOptionalMemberAccess` from an error to informational, since the model change references `self.assigned_user.get_full_name()` and pylance can't figure out that `self.assigned_user` is a Django `User` object and has a `get_full_name()` method.  You may need to [rebuild your dev container](https://github.com/UCLALibrary/ftva-lab-data#dev-container) for the change to take effect.

### Testing

No restart needed, as the model changes just add a property (calculated after data is retrieved from the database), so there's no migration from this.  Since ORM queries must run against the database, that's also why I opted not to add support for searching `assigned_user_full_name` itself - it's not in the database.

There are 8 new tests in `SearchTestCase`, bringing the total to 30; all should pass.


[SYS-1864]: https://uclalibrary.atlassian.net/browse/SYS-1864?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SYS-1863]: https://uclalibrary.atlassian.net/browse/SYS-1863?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ