### PR TITLE
SYS-1866: Support carrier search and display

### DIFF
--- a/charts/prod-ftvalabdata-values.yaml
+++ b/charts/prod-ftvalabdata-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/ftva-lab-data
-  tag: v0.9.1
+  tag: v0.9.2
   pullPolicy: Always
 
 nameOverride: ""

--- a/ftva_lab_data/models.py
+++ b/ftva_lab_data/models.py
@@ -79,8 +79,24 @@ class SheetImport(models.Model):
         return f"id: {self.id} --- file: {self.file_name} --- title: {self.title}"
 
     @property
-    def assigned_user_full_name(self):
+    def assigned_user_full_name(self) -> str:
         return self.assigned_user.get_full_name()
+
+    @property
+    def carrier_a_with_location(self) -> str:
+        return (
+            f"{self.carrier_a} ({self.carrier_a_location})"
+            if self.carrier_a_location
+            else self.carrier_a
+        )
+
+    @property
+    def carrier_b_with_location(self) -> str:
+        return (
+            f"{self.carrier_b} ({self.carrier_b_location})"
+            if self.carrier_b_location
+            else self.carrier_b
+        )
 
     class Meta:
         permissions = [("assign_user", "Can assign user to SheetImport")]

--- a/ftva_lab_data/table_config.py
+++ b/ftva_lab_data/table_config.py
@@ -3,6 +3,8 @@
 # Field names must be valid from SheetImport model.
 COLUMNS = [
     ("hard_drive_name", "Hard drive"),
+    ("carrier_a", "Carrier A"),
+    ("carrier_b", "Carrier B"),
     ("file_folder_name", "File folder"),
     ("sub_folder_name", "Sub-folder"),
     ("file_name", "Filename"),

--- a/ftva_lab_data/table_config.py
+++ b/ftva_lab_data/table_config.py
@@ -3,8 +3,8 @@
 # Field names must be valid from SheetImport model.
 COLUMNS = [
     ("hard_drive_name", "Hard drive"),
-    ("carrier_a", "Carrier A"),
-    ("carrier_b", "Carrier B"),
+    ("carrier_a_with_location", "Carrier A"),
+    ("carrier_b_with_location", "Carrier B"),
     ("file_folder_name", "File folder"),
     ("sub_folder_name", "Sub-folder"),
     ("file_name", "Filename"),

--- a/ftva_lab_data/templates/partials/search_results_table.html
+++ b/ftva_lab_data/templates/partials/search_results_table.html
@@ -16,16 +16,20 @@
     <colgroup>
         <!--Hard drive-->
         <col style="width: 10%;">
+        <!--Carrier A-->
+        <col style="width: 10%;">
+        <!--Carrier A-->
+        <col style="width: 10%;">
         <!--File folder-->
         <col style="width: 10%;">
         <!--Sub-folder-->
         <col style="width: 10%;">
         <!--Filename-->
-        <col style="width: 25%;">
+        <col style="width: 10%;">
         <!--Source inv no.-->
         <col style="width: 10%;">
         <!--Status-->
-        <col style="width: 16%;">
+        <col style="width: 11%;">
         <!--Assigned user-->
         <col style="width: 9%;">
         <!--View link-->

--- a/ftva_lab_data/templates/partials/search_results_table.html
+++ b/ftva_lab_data/templates/partials/search_results_table.html
@@ -57,8 +57,6 @@
                         {% for status in value %}
                             <span class="badge rounded-pill bg-info text-dark m-1">{{ status }}</span>
                         {% endfor %}
-                    {% elif field == "assigned_user_full_name" %}
-                        {{ value }}
                     {% else %}
                         {{ value }}
                     {% endif %}     

--- a/ftva_lab_data/tests.py
+++ b/ftva_lab_data/tests.py
@@ -398,6 +398,8 @@ class SearchTestCase(TestCase):
             sub_folder_name="SF1",
             file_name="F1",
             inventory_number="Inv_No",
+            carrier_a="ABC123",
+            carrier_a_location="VAULT-01",
         )
 
         # Basic item with a user assigned
@@ -494,3 +496,17 @@ class SearchTestCase(TestCase):
         )
         self.assertEqual(items.count(), 1)
         self.assertEqual(items.all()[0], self.item_with_user)
+
+    def test_search_finds_carrier_in_property_field(self):
+        items = get_search_result_items(
+            search="ABC123",
+            search_fields=["carrier_a_with_location"],
+        )
+        self.assertEqual(items.all()[0], self.item_basic)
+
+    def test_search_finds_carrier_location_in_property_field(self):
+        items = get_search_result_items(
+            search="VAULT-01",
+            search_fields=["carrier_a_with_location"],
+        )
+        self.assertEqual(items.all()[0], self.item_basic)

--- a/ftva_lab_data/tests.py
+++ b/ftva_lab_data/tests.py
@@ -16,7 +16,7 @@ from ftva_lab_data.models import ItemStatus, SheetImport
 from ftva_lab_data.views_utils import (
     get_field_value,
     get_item_display_dicts,
-    get_search_items,
+    get_search_result_items,
 )
 from ftva_lab_data.table_config import COLUMNS
 
@@ -424,7 +424,7 @@ class SearchTestCase(TestCase):
         cls.search_fields = [field for field, _ in COLUMNS]
 
     def test_search_is_case_insensitive(self):
-        items = get_search_items(
+        items = get_search_result_items(
             # Data is uppercase, search term is lowercase
             search="ff1",
             search_fields=["file_folder_name"],
@@ -432,7 +432,7 @@ class SearchTestCase(TestCase):
         self.assertEqual(items.all()[0], self.item_basic)
 
     def test_search_finds_unique_record(self):
-        items = get_search_items(
+        items = get_search_result_items(
             search="FF1",
             search_fields=["file_folder_name"],
         )
@@ -440,7 +440,7 @@ class SearchTestCase(TestCase):
         self.assertEqual(items.all()[0], self.item_basic)
 
     def test_search_finds_substring(self):
-        items = get_search_items(
+        items = get_search_result_items(
             # One record has file_name with 'embed' in the middle
             search="embed",
             search_fields=["file_name"],
@@ -449,7 +449,7 @@ class SearchTestCase(TestCase):
         self.assertEqual(items.all()[0], self.item_with_user)
 
     def test_search_finds_term_in_different_fields(self):
-        items = get_search_items(
+        items = get_search_result_items(
             # Two records have 'Inv_No', each in a different field
             search="Inv_No",
             # No search column defined, so search all fields
@@ -458,7 +458,7 @@ class SearchTestCase(TestCase):
         self.assertEqual(items.count(), 2)
 
     def test_search_finds_status_in_all_fields(self):
-        items = get_search_items(
+        items = get_search_result_items(
             # One record has a status assigned
             search="Test status",
             # No search column defined, so search all fields
@@ -468,7 +468,7 @@ class SearchTestCase(TestCase):
         self.assertEqual(items.all()[0], self.item_with_status)
 
     def test_search_finds_status_in_status_field(self):
-        items = get_search_items(
+        items = get_search_result_items(
             # One record has a status assigned
             search="Test status",
             search_fields=["status"],
@@ -477,7 +477,7 @@ class SearchTestCase(TestCase):
         self.assertEqual(items.all()[0], self.item_with_status)
 
     def test_search_finds_user_in_all_fields(self):
-        items = get_search_items(
+        items = get_search_result_items(
             # One record has a user assigned
             search="testuser",
             # No search column defined, so search all fields
@@ -487,7 +487,7 @@ class SearchTestCase(TestCase):
         self.assertEqual(items.all()[0], self.item_with_user)
 
     def test_search_finds_user_in_user_field(self):
-        items = get_search_items(
+        items = get_search_result_items(
             # One record has a user assigned
             search="testuser",
             search_fields=["assigned_user_full_name"],

--- a/ftva_lab_data/views.py
+++ b/ftva_lab_data/views.py
@@ -14,7 +14,7 @@ from .views_utils import (
     get_field_value,
     get_item_display_dicts,
     get_add_edit_item_fields,
-    get_search_items,
+    get_search_result_items,
 )
 
 
@@ -117,7 +117,7 @@ def render_search_results_table(request: HttpRequest) -> HttpResponse:
     # otherwise, search in all display fields.
     search_fields = [search_column] if search_column else display_fields
 
-    items = get_search_items(search, search_fields)
+    items = get_search_result_items(search, search_fields)
 
     paginator = Paginator(items, 10)
     page_obj = paginator.get_page(page)

--- a/ftva_lab_data/views.py
+++ b/ftva_lab_data/views.py
@@ -11,9 +11,9 @@ from .forms import ItemForm
 from .models import SheetImport
 from .table_config import COLUMNS
 from .views_utils import (
-    get_field_value,
     get_item_display_dicts,
     get_add_edit_item_fields,
+    get_search_result_data,
     get_search_result_items,
 )
 
@@ -124,15 +124,9 @@ def render_search_results_table(request: HttpRequest) -> HttpResponse:
 
     # Construct of list of dicts to use as table rows instead of QuerySets
     # allowing row[field] to be accessed, rather than specifying each field literal.
-    # Set ID as a seperate property so it is not displayed as column header,
-    # but can still be accessed for links.
-    rows = [
-        {
-            "data": {field: get_field_value(item, field) for field in display_fields},
-            "id": item.id,
-        }
-        for item in page_obj.object_list
-    ]
+    rows = get_search_result_data(
+        item_list=page_obj.object_list, display_fields=display_fields
+    )
 
     return render(
         request,

--- a/ftva_lab_data/views_utils.py
+++ b/ftva_lab_data/views_utils.py
@@ -190,4 +190,5 @@ def get_search_result_data(
         }
         for item in item_list
     ]
+
     return rows

--- a/ftva_lab_data/views_utils.py
+++ b/ftva_lab_data/views_utils.py
@@ -132,7 +132,7 @@ def get_add_edit_item_fields(form: ItemForm) -> dict[str, list[str]]:
     return {"basic_fields": basic_fields, "advanced_fields": advanced_fields}
 
 
-def get_search_items(search: str, search_fields: list[str]) -> QuerySet:
+def get_search_result_items(search: str, search_fields: list[str]) -> QuerySet:
     """Searches for `search` term in `search_fields`.  Field names must be present
     in ftva_lab_data.table_config.
 

--- a/ftva_lab_data/views_utils.py
+++ b/ftva_lab_data/views_utils.py
@@ -143,7 +143,7 @@ def get_search_items(search: str, search_fields: list[str]) -> QuerySet:
     # of search from display.
     items = SheetImport.objects.all().order_by("id")
 
-    # General CTRL-F-style search across requested fields.
+    # General CTRL-F-style substring search across requested fields.
     # Start with empty Q() object, then add queries for all requested fields.
     query = Q()
     for field in search_fields:
@@ -155,6 +155,12 @@ def get_search_items(search: str, search_fields: list[str]) -> QuerySet:
             query |= Q(assigned_user__last_name__icontains=search)
             query |= Q(assigned_user__first_name__icontains=search)
             query |= Q(assigned_user__username__icontains=search)
+        elif field == "carrier_a":
+            query |= Q(carrier_a__icontains=search)
+            query |= Q(carrier_a_location__icontains=search)
+        elif field == "carrier_b":
+            query |= Q(carrier_b__icontains=search)
+            query |= Q(carrier_b_location__icontains=search)
         else:
             query |= Q(**{f"{field}__icontains": search})
     # Finally, apply the query, using distinct() to remove dups possible with multiple statuses.


### PR DESCRIPTION
Implements [SYS-1866](https://uclalibrary.atlassian.net/browse/SYS-1866).  Sets version to `v0.9.2` for deployment.

This PR adds the ability to search for (tape) carrier information, and adds it to the search results display.  Users can search for either "Carrier A" or "Carrier B"  specifically, and these fields are included in the "All columns" search as well.

Two new columns are added to the search results template (via `partials/search_results_table.html`).  Some other columns were made narrower to make room.

Each "Carrier" column includes data from up to two fields: the carrier field itself, and its corresponding location field.  I chose to implement this via properties in `SheetImport`, for `carrier_a_with_location` and `carrier_b_with_location`.  This allows us to continue using the same generic data retrieval, but I moved that from `views.render_search_results_table()` to `views_utils.get_search_result_data()` for better separation / reuse / documentation.  

### Testing

No restart needed, the model changes do not affect the database.

I chose *not* to add tests for `get_search_result_data()`, as it does nothing complex and the method it uses, `get_field_data()`, already has tests.  However, I did add 2 new simple tests to `SearchTestCase()`, confirming that data in the underlying model fields is retrieved correctly.

There now are 32 tests, all passing.

For manual testing, please just check the search results display to confirm everything fits and looks as good as it can given the data and the display limitations.

