### PR TITLE
SYS-1870: Fix behavior of "Back to Search" button

### DIFF
--- a/ftva_lab_data/templates/add_edit_item.html
+++ b/ftva_lab_data/templates/add_edit_item.html
@@ -19,7 +19,7 @@
         </div>
 
         <a class="btn btn-outline-danger"
-            href="{% if item %}{% url 'view_item' item.id %}{% else %}{% url 'search_results' %}{% endif %}">
+            href="{% if item %}{% url 'view_item' item.id %}{% else %}{% url 'search_results' %}{% endif %}?search={{ search }}&search_column={{ search_column }}&page={{ page }}">
             Cancel</a>
     </div>
 

--- a/ftva_lab_data/templates/add_edit_item.html
+++ b/ftva_lab_data/templates/add_edit_item.html
@@ -30,7 +30,11 @@
             <div class="col">
             {% for field in form %}
                 {% if field.name in basic_fields %}
-                    {% bootstrap_field field %}
+                    {% if field.name == "file_name" %}
+                        {% bootstrap_field field required="True"%}
+                    {% else %}
+                        {% bootstrap_field field %}
+                    {% endif %}
                 {% endif %}
                 {% if field.name == "notes"  or field.name == "hard_drive_barcode_id"%}
                     </div><div class="col">

--- a/ftva_lab_data/templates/add_edit_item.html
+++ b/ftva_lab_data/templates/add_edit_item.html
@@ -30,11 +30,7 @@
             <div class="col">
             {% for field in form %}
                 {% if field.name in basic_fields %}
-                    {% if field.name == "file_name" %}
-                        {% bootstrap_field field required="True"%}
-                    {% else %}
-                        {% bootstrap_field field %}
-                    {% endif %}
+                    {% bootstrap_field field %}
                 {% endif %}
                 {% if field.name == "notes"  or field.name == "hard_drive_barcode_id"%}
                     </div><div class="col">

--- a/ftva_lab_data/templates/partials/search_results_table.html
+++ b/ftva_lab_data/templates/partials/search_results_table.html
@@ -67,6 +67,7 @@
                 </td>         
             {% endfor %}
             <td>
+                <!--View link includes search parameters, for later use by "Back to Search" button-->
                 <a class="btn btn-link btn-sm" href="{% url 'view_item' row.id %}?search={{ search }}&search_column={{ search_column }}&page={{ page_obj.number }}">View</a>
             </td>
             <td class="align-top">

--- a/ftva_lab_data/templates/partials/search_results_table.html
+++ b/ftva_lab_data/templates/partials/search_results_table.html
@@ -67,7 +67,7 @@
                 </td>         
             {% endfor %}
             <td>
-                <a class="btn btn-link btn-sm" href="{% url 'view_item' row.id %}">View</a>
+                <a class="btn btn-link btn-sm" href="{% url 'view_item' row.id %}?search={{ search }}&search_column={{ search_column }}&page={{ page_obj.number }}">View</a>
             </td>
             <td class="align-top">
                 <div class="form-check justify-content-center m-0" style="display: flex;">

--- a/ftva_lab_data/templates/search_results.html
+++ b/ftva_lab_data/templates/search_results.html
@@ -19,11 +19,11 @@
         <select name="search_column" class="form-select form-select-md">
             <option value="">All columns</option>
             {% for field, label in columns %}
-            <option value="{{ field }}">{{ label }}</option>
+            <option value="{{ field }}" {% if field == search_column %}selected{% endif %}>{{ label }}</option>
             {% endfor %}
         </select>
         <div class="input-group input-group-md">
-            <input id="search-input" class="form-control form-control-md" type="text" name="search" placeholder="Enter search term...">
+            <input id="search-input" class="form-control form-control-md" type="text" name="search" placeholder="Enter search term..." value="{{ search }}">
             <span class="input-group-text">
                 <button class="btn p-0 border-0" type="button" hx-on:click="clearSearchInput()">
                     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor"
@@ -55,7 +55,9 @@
 
 <!-- On page load, HTMX triggers GET request to 'render_table'
 and inserts it within div -->
-<div id="table-container" class="table-responsive container-fluid p-4" hx-get="{% url 'render_table' %}" hx-trigger="load"></div>
-
+<div id="table-container" class="table-responsive container-fluid p-4"
+     hx-get="{% url 'render_table' %}?search={{ search }}&search_column={{ search_column }}&page={{ page }}"
+     hx-trigger="load">
+</div>
 
 {% endblock %}

--- a/ftva_lab_data/templates/view_item.html
+++ b/ftva_lab_data/templates/view_item.html
@@ -25,7 +25,10 @@
             <button id="toggle-advanced-fields" class="btn btn-secondary" type="button"
                 hx-on:click="toggleAdvancedFields(this)">Show Advanced Fields</button>
             {% if perms.ftva_lab_data.change_sheetimport %}
-            <a class="btn btn-primary" href="{% url 'edit_item' header_info.id %}">Edit This Record</a>
+            <a class="btn btn-primary"
+            href="{% url 'edit_item' header_info.id %}?search={{ search }}&search_column={{ search_column }}&page={{ page }}">
+            Edit This Record
+            </a>
             {% endif %}
         </div>
 

--- a/ftva_lab_data/templates/view_item.html
+++ b/ftva_lab_data/templates/view_item.html
@@ -29,7 +29,10 @@
             {% endif %}
         </div>
 
-        <a class="btn btn-outline-secondary" href="{% url 'search_results' %}">Back to Search</a>
+        <a class="btn btn-outline-secondary"
+        href="{% url 'search_results' %}?search={{ search }}&search_column={{ search_column }}&page={{ page }}">
+        Back to Search
+        </a>
     </div>
 
     <div class="row">

--- a/ftva_lab_data/tests.py
+++ b/ftva_lab_data/tests.py
@@ -111,7 +111,8 @@ class UserAccessTestCase(TestCase):
 
         # POST request
         response = self.client.post(url, self.test_form_data)
-        self.assertEqual(response.status_code, 200)
+        # Should redirect after successful POST
+        self.assertEqual(response.status_code, 302)
         # Confirm item successfully updated in database
         self.test_object.refresh_from_db()
         self.assertEqual(self.test_object.file_name, self.test_form_data["file_name"])

--- a/ftva_lab_data/views.py
+++ b/ftva_lab_data/views.py
@@ -90,14 +90,33 @@ def view_item(request, item_id):
     item = SheetImport.objects.get(id=item_id)
     # For easier parsing in the template, separate attributes into dictionaries
     display_dicts = get_item_display_dicts(item)
+    # Pass search params to template, so they can be preserved
+    # if using the "Back to Search" button
+    display_dicts.update(
+        {
+            "search": request.GET.get("search", ""),
+            "search_column": request.GET.get("search_column", ""),
+            "page": request.GET.get("page", ""),
+        }
+    )
     return render(request, "view_item.html", display_dicts)
 
 
 @login_required
 def search_results(request: HttpRequest) -> HttpResponse:
     users = get_user_model().objects.all().order_by("username")
+    # Pass search params from GET to template context,
+    # so we can consistently render the results table after navigation
     return render(
-        request, "search_results.html", context={"columns": COLUMNS, "users": users}
+        request,
+        "search_results.html",
+        context={
+            "columns": COLUMNS,
+            "users": users,
+            "search": request.GET.get("search", ""),
+            "search_column": request.GET.get("search_column", ""),
+            "page": request.GET.get("page", 1),
+        },
     )
 
 

--- a/ftva_lab_data/views.py
+++ b/ftva_lab_data/views.py
@@ -1,4 +1,5 @@
-from django.shortcuts import render, redirect, reverse
+from django.shortcuts import render, redirect
+from django.urls import reverse
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required, permission_required
 from django.core.paginator import Paginator


### PR DESCRIPTION
Implements [SYS-1870](https://uclalibrary.atlassian.net/browse/SYS-1870)

Adds new `search`, `search_column`, and `page` context values for the `view_item` and `search_results` templates. These allow the "Back to Search" button to return the user to the exact search screen seen before clicking on the item page.

Testing:
Perform a search with some combination of filters and page navigation. Click a "View" link to display a record. Click "Back to Results" and note that your search term, search column, and page number were preserved.

[SYS-1870]: https://uclalibrary.atlassian.net/browse/SYS-1870?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ