### PR TITLE
SYS-1862: Import inventory numbers

### DIFF
--- a/ftva_lab_data/management/commands/import_status_and_inventory_numbers.py
+++ b/ftva_lab_data/management/commands/import_status_and_inventory_numbers.py
@@ -163,7 +163,7 @@ class Command(BaseCommand):
                 record = matched_records.first()
                 if process_inventory:
                     # If the record already has an inventory number, and it is different
-                    # from the one in the sheet, it add to the report with before and after values.
+                    # from the one in the sheet, add it to the report with before and after values.
                     if (
                         record.inventory_number
                         and record.inventory_number != row["inventory_number"]

--- a/ftva_lab_data/management/commands/import_status_and_inventory_numbers.py
+++ b/ftva_lab_data/management/commands/import_status_and_inventory_numbers.py
@@ -178,6 +178,7 @@ class Command(BaseCommand):
                             }
                         )
                     record.inventory_number = row["inventory_number"]
+                    record.save()
                 if process_status:
                     record.status.set(row["status_ids"])
                 records_updated += 1

--- a/ftva_lab_data/tests.py
+++ b/ftva_lab_data/tests.py
@@ -13,7 +13,7 @@ from ftva_lab_data.management.commands.clean_imported_data import (
     set_hard_drive_names,
 )
 from ftva_lab_data.models import ItemStatus, SheetImport
-from ftva_lab_data.management.commands.import_status_info import (
+from ftva_lab_data.management.commands.import_status_and_inventory_numbers import (
     parse_status_info,
 )
 from ftva_lab_data.views_utils import (

--- a/process_data.sh
+++ b/process_data.sh
@@ -47,5 +47,5 @@ docker compose exec django python manage.py clean_tape_info --update_records
 
 # Import status info
 echo ""
-echo "Importing status info..."
-docker compose exec django python manage.py import_status_info --file_name copy_dl_sheet_2024-10-18.xlsx
+echo "Importing status and inventory number info..."
+docker compose exec django python manage.py import_status_and_inventory_numbers --file_name copy_dl_sheet_2024-10-18.xlsx -s -i


### PR DESCRIPTION
Implements [SYS-1862](https://uclalibrary.atlassian.net/browse/SYS-1861)

Builds off work done in [SYS-1861](https://uclalibrary.atlassian.net/browse/SYS-1862). The management command `import_status_info` is renamed to `import_status_and_inventory_numbers`. This command supports two options, which can be combined: `-s` to import Status info, and `-i` to import inventory numbers.

If Inventory Numbers are updated, the output report will contain a new sheet with information about the before and after values for all items with a changed Inventory Number.

`process_data.sh` has been updated to import both Status and Inventory Number information with the complete data load. When running this, I see these results:

```
18938 records updated
359 rows returned more than one match
164 rows returned no match
7 records had changed inventory numbers
```

To run the command: `python manage.py import_status_and_inventory_numbers --file_name copy_dl_sheet_2024-10-18.xlsx [-s] [-i]`

No new tests are added, but import statements in `tests.py` were updated to use the new command name.

[SYS-1862]: https://uclalibrary.atlassian.net/browse/SYS-1862?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SYS-1861]: https://uclalibrary.atlassian.net/browse/SYS-1861?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ