### PR TITLE
SYS-1876: Make record_id visible and searchable

### DIFF
--- a/charts/prod-ftvalabdata-values.yaml
+++ b/charts/prod-ftvalabdata-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/ftva-lab-data
-  tag: v0.9.2
+  tag: v0.9.3
   pullPolicy: Always
 
 nameOverride: ""

--- a/ftva_lab_data/table_config.py
+++ b/ftva_lab_data/table_config.py
@@ -11,4 +11,5 @@ COLUMNS = [
     ("inventory_number", "Inventory number"),
     ("status", "Status"),
     ("assigned_user_full_name", "Assigned user"),
+    ("id", "Record ID"),
 ]

--- a/ftva_lab_data/templates/add_edit_item.html
+++ b/ftva_lab_data/templates/add_edit_item.html
@@ -10,6 +10,9 @@
 
 <div class="container">
     <h1>{{ title }}</h1>
+    {% if item %}
+        <p class="fs-5">Editing Item: {{ item.id }}</p>
+    {% endif %}
     <!-- Buttons -->
     <div class="d-flex justify-content-between mb-3">
         <div class="d-flex gap-2">

--- a/ftva_lab_data/templates/partials/search_results_table.html
+++ b/ftva_lab_data/templates/partials/search_results_table.html
@@ -32,7 +32,7 @@
         <col style="width: 11%;">
         <!--Assigned user-->
         <col style="width: 9%;">
-        <!--View link-->
+        <!--View link and Record ID-->
         <col style="width: 5%;">
         <!--Checkbox for assigning-->
         <col style="width: 5%;">
@@ -40,10 +40,12 @@
     <thead>
         <tr>
             {% for _, label in columns %}
-            <th>{{ label }}</th>
+                {% if label == "Record ID" %}
+                    <th></th>
+                {% else %}
+                    <th>{{ label }}</th>
+                {% endif %}
             {% endfor %}
-            <!--Empty <th> for View link-->
-            <th></th>
             <th class ="text-center">
                 Assign
                 <div class="form-check justify-content-center m-0" style="display: flex;" title="Select all items on this page">
@@ -61,15 +63,20 @@
                         {% for status in value %}
                             <span class="badge rounded-pill bg-info text-dark m-1">{{ status }}</span>
                         {% endfor %}
+                    {% elif field == "id" %}
+                        <div class="d-flex flex-column align-items-start">
+                            <!--View link includes search parameters, for later use by "Back to Search" button-->
+                            <a class="btn btn-link btn-sm p-0" 
+                            href="{% url 'view_item' row.id %}?search={{ search }}&search_column={{ search_column }}&page={{ page_obj.number }}">
+                            View</a> 
+                            <br>
+                            <span class="text-muted small">ID: {{ value }}</span>
+                        </div>
                     {% else %}
                         {{ value }}
                     {% endif %}     
                 </td>         
-            {% endfor %}
-            <td>
-                <!--View link includes search parameters, for later use by "Back to Search" button-->
-                <a class="btn btn-link btn-sm" href="{% url 'view_item' row.id %}?search={{ search }}&search_column={{ search_column }}&page={{ page_obj.number }}">View</a>
-            </td>
+            {% endfor %}                    
             <td class="align-top">
                 <div class="form-check justify-content-center m-0" style="display: flex;">
                     <input type="checkbox" class="form-check-input row-checkbox checkbox-bold" name="selected_ids" value="{{ row.id }}">

--- a/ftva_lab_data/templates/view_item.html
+++ b/ftva_lab_data/templates/view_item.html
@@ -13,6 +13,7 @@
 
     <p class="fs-5">{% if header_info.file_name %} File: {{ header_info.file_name }} {% endif %}</p>
     <p class="fs-5">{% if header_info.title %} (Title: {{ header_info.title }}) {% endif %}</p>
+    <p class="fs-5">{% if header_info.id %} Record ID: {{ header_info.id }} {% endif %}</p>
     <p class="fs-5">{% if header_info.status %} Status: 
         {% for status in header_info.status %}
             <span class="badge rounded-pill bg-info text-dark m-1">{{ status }}</span>


### PR DESCRIPTION
Implements [SYS-1876](https://uclalibrary.atlassian.net/browse/SYS-1876)

Adds `record_id` (The Django internal record identifier) as a searchable data value, and displays it in the following places:
* In search results, sharing a column with the View link
* On View Item pages, with other header metadata
* On Edit Item pages, directly under the page title

Also includes tag bump for deployment. Let me know if you think any of the display/layout could be improved.
<img width="1350" alt="image" src="https://github.com/user-attachments/assets/e7e89ef2-7b8c-48ec-926a-d8ee1a60318a" />

<img width="468" alt="image" src="https://github.com/user-attachments/assets/4ac359aa-215c-4b35-8dfb-b08be9d4968b" />

<img width="368" alt="image" src="https://github.com/user-attachments/assets/402b7d30-7dea-4ed5-b626-c373c68c9426" />