### PR TITLE
SYS-1871: Add `Deletion requested` status

### DIFF
--- a/ftva_lab_data/fixtures/item_statuses.json
+++ b/ftva_lab_data/fixtures/item_statuses.json
@@ -1,4 +1,4 @@
-[ 
+[
   {
     "model": "ftva_lab_data.itemstatus",
     "pk": 1,
@@ -39,6 +39,13 @@
     "pk": 6,
     "fields": {
       "status": "Multiple matching inv no in PD"
+    }
+  },
+  {
+    "model": "ftva_lab_data.itemstatus",
+    "pk": 7,
+    "fields": {
+      "status": "Deletion requested"
     }
   }
 ]


### PR DESCRIPTION
Implements [SYS-1871](https://uclalibrary.atlassian.net/browse/SYS-1871)

This is a straightforward change--just added a status item for "Deletion requested" to the `item_statuses` fixture.

### Acceptance criteria
- ✅ A status "Deletion requested" is added to the item_statuses.json fixture

### Testing
Please manually confirm that the "Deletion requested" status appears in the edit view and behaves as it should.

[SYS-1871]: https://uclalibrary.atlassian.net/browse/SYS-1871?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ