### PR TITLE
SYS-1873: Add visual indicator for required input fields

### DIFF
--- a/charts/prod-ftvalabdata-values.yaml
+++ b/charts/prod-ftvalabdata-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/ftva-lab-data
-  tag: v0.9.3
+  tag: v0.9.4
   pullPolicy: Always
 
 nameOverride: ""

--- a/ftva_lab_data/templates/add_edit_item.html
+++ b/ftva_lab_data/templates/add_edit_item.html
@@ -33,7 +33,20 @@
             <div class="col">
             {% for field in form %}
                 {% if field.name in basic_fields %}
-                    {% bootstrap_field field %}
+                    <!-- `field.field` accesses actual field instance, rather than wrapper -->
+                    {% if field.field.required %}
+                        <div class="mb-3">
+                            <label
+                                for="id_file_name"
+                                class="form-label required-field-label"
+                                data-bs-toggle="tooltip"
+                                title="Required field"
+                            >{{ field.label }}</label>
+                            <input type="text" class="form-control" id="id_file_name" placeholder="{{ field.label }}" required>
+                        </div>
+                    {% else %}
+                        {% bootstrap_field field %}
+                    {% endif %}
                 {% endif %}
                 {% if field.name == "notes"  or field.name == "hard_drive_barcode_id"%}
                     </div><div class="col">

--- a/ftva_lab_data/templates/add_edit_item.html
+++ b/ftva_lab_data/templates/add_edit_item.html
@@ -60,7 +60,19 @@
             <div class="col">
             {% for field in form %}
                 {% if field.name in advanced_fields %}
-                    {% bootstrap_field field %}
+                    {% if field.field.required %}
+                        <div class="mb-3">
+                            <label
+                                for="id_file_name"
+                                class="form-label required-field-label"
+                                data-bs-toggle="tooltip"
+                                title="Required field"
+                            >{{ field.label }}</label>
+                            <input type="text" class="form-control" id="id_file_name" placeholder="{{ field.label }}" required>
+                        </div>
+                    {% else %}
+                        {% bootstrap_field field %}
+                    {% endif %}
                 {% endif %}
                 {% if field.name == "color_bit_depth"  or field.name == "date_audio_edit_completed" %}
                     </div><div class="col">

--- a/ftva_lab_data/tests.py
+++ b/ftva_lab_data/tests.py
@@ -586,3 +586,42 @@ class ItemStatusTestCase(TestCase):
                 # Using sets to check equivalence
                 # because order shouldn't matter here.
                 self.assertSetEqual(set(parsed_status), set(expected_status_ids))
+
+
+class AddEditItemTestCase(TestCase):
+    """Tests for the `add_item` and `edit_item` views."""
+
+    fixtures = ["sample_data.json", "groups_and_permissions.json"]
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.client = Client()
+
+        cls.authorized_user = User.objects.create_user(
+            username="authorized", password="testpassword"
+        )
+        editors_group = Group.objects.get(name="editors")
+        cls.authorized_user.groups.add(editors_group)
+
+        cls.test_object = SheetImport.objects.get(pk=2)
+
+    def test_required_fields_display_with_indicator(self):
+        self.client.login(username="authorized", password="testpassword")
+        url = reverse("add_item")
+
+        response = self.client.get(url)
+
+        # At minimum, the label for the `file_name` field should have `required-field-label`
+        # in its CSS class list, which appends an asterisk using the CSS `::after` pseudo-element.
+        # The presence of this class should be enough to prove that
+        # the conditional block in `add_edit_item.html` is working.
+        expected_markup = (
+            '<label for="id_file_name" class="form-label required-field-label"'
+            'data-bs-toggle="tooltip" title="Required field">File name</label>'
+        )
+        self.assertContains(
+            response=response,
+            text=expected_markup,
+            count=1,
+            html=True,
+        )

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -3,5 +3,12 @@
 }
 
 #table-container td {
-    word-break: break-all;
+  word-break: break-all;
+}
+
+/* Used to add an asterisk on label
+for required input fields*/
+label.required-field-label::after {
+  content: " *";
+  color: red;
 }

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -1,3 +1,8 @@
+// enables tooltips
+// see @https://getbootstrap.com/docs/5.2/components/tooltips/
+const tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]')
+const tooltipList = [...tooltipTriggerList].map(tooltipTriggerEl => new bootstrap.Tooltip(tooltipTriggerEl))
+
 function toggleAdvancedFields(el) {
   const advancedFields = document.getElementById("advanced-fields");
   const isHidden = (advancedFields.hidden = !advancedFields.hidden);
@@ -60,11 +65,11 @@ document.addEventListener("htmx:afterSwap", function (e) {
   }
 });
 
-document.addEventListener("DOMContentLoaded", function() {
-    const searchForm = document.querySelector('form[hx-get]');
-    if (searchForm) {
-        searchForm.addEventListener('submit', function(e) {
-            e.preventDefault(); // Prevent form submission on Enter
-        });
-    }
+document.addEventListener("DOMContentLoaded", function () {
+  const searchForm = document.querySelector('form[hx-get]');
+  if (searchForm) {
+    searchForm.addEventListener('submit', function (e) {
+      e.preventDefault(); // Prevent form submission on Enter
+    });
+  }
 });


### PR DESCRIPTION
Implements [SYS-1873](https://uclalibrary.atlassian.net/browse/SYS-1873)

### Acceptance criteria
- ✅ Update the Add/Edit item display to visually show that Filename is a required field, using an asterisk or other indicator.

### Description
In the Add/Edit item view, labels for required fields now show a red asterisks and a tooltip on hover over the label. The tooltip is in addition to the default browser tooltip that displays on hover over the input element itself.

I replaced the `django-bootstrap` template element with HTML elements to have more control over the label attributes, as I wanted to use the Bootstrap tooltip documented [here](https://getbootstrap.com/docs/5.2/components/tooltips/). The tooltip requires a couple lines of JavaScript, and the asterisks gets appended by a new CSS class. Whether a field is required or not is determined by the `blank=False` parameter of the underlying model field.

So far, `file_name` is the only field with `blank=False` (i.e. cannot be blank, i.e. is required). Any additional fields set to `blank=False` should get the asterisks in the label automatically now.

### Testing
I added one unit test, which checks that the label for the file name field in the `add_item` view has `required-field-label` in its class list. This class triggers the CSS `::after` pseudo-element to append an asterisks. Since it's a pseudo-element, it doesn't show up directly in the HTML returned to the test `GET` call, but I think we can trust the CSS will work.

Since `add_item` and `edit_item` share a template, I figured it was okay to just test `add_item`. Let me know if you disagree though, and I'm happy to add to the test.

One manual test you can do to confirm the changes work as intended is to change any number of `SheetImport` fields in `models.py` to have `blank=False` as a parameter. Those fields should then show up with an asterisk and tooltip.

### Reference screen capture
![screencap](https://github.com/user-attachments/assets/5d45ed76-122e-4d79-acea-b53b3ddaaf3c)


[SYS-1873]: https://uclalibrary.atlassian.net/browse/SYS-1873?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ