### PR TITLE
SYS-1880: Export search results

### DIFF
--- a/charts/prod-ftvalabdata-values.yaml
+++ b/charts/prod-ftvalabdata-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/ftva-lab-data
-  tag: v0.9.5.1
+  tag: v0.9.6
   pullPolicy: Always
 
 nameOverride: ""

--- a/ftva_lab_data/models.py
+++ b/ftva_lab_data/models.py
@@ -17,7 +17,9 @@ class SheetImport(models.Model):
     # These 3 "id" fields seem to often contain longer notes...
     # dml_lto_tape_id is now carrier_a; arsc_lto_tape_id is now carrier_b
     carrier_a = models.CharField(max_length=100, blank=True)
+    carrier_a_location = models.CharField(max_length=25, blank=True)
     carrier_b = models.CharField(max_length=100, blank=True)
+    carrier_b_location = models.CharField(max_length=25, blank=True)
     hard_drive_barcode_id = models.CharField(max_length=100, blank=True)
     file_folder_name = models.CharField(max_length=200, blank=True)
     sub_folder_name = models.CharField(max_length=200, blank=True)
@@ -75,8 +77,6 @@ class SheetImport(models.Model):
         related_name="sheet_imports",
     )
     history = HistoricalRecords()
-    carrier_a_location = models.CharField(max_length=25, blank=True)
-    carrier_b_location = models.CharField(max_length=25, blank=True)
 
     def __str__(self):
         return f"id: {self.id} --- file: {self.file_name} --- title: {self.title}"

--- a/ftva_lab_data/templates/search_results.html
+++ b/ftva_lab_data/templates/search_results.html
@@ -50,14 +50,20 @@
         <button type="submit" class="btn btn-sm btn-primary">Assign Selected</button>
     </form>
     {% endif %}
-    <form method="get" action="{% url 'export_search_results' %}" class="mb-3">
+    <form method="get" action="{% url 'export_search_results' %}" class="mb-3" id="export-form">
+        {% csrf_token %}
         <input type="hidden" name="search" value="{{ search }}">
         <input type="hidden" name="search_column" value="{{ search_column }}">
-        <button type="submit" class="btn btn-outline-success">
+        <button type="button" class="btn btn-outline-success" id="export-button">
             Export to Excel
         </button>
     </form>
 </div> 
+
+<div id="export-spinner" class="text-center my-3" style="display: none;">
+  <div class="spinner-border text-success" role="status"></div>
+  <div class="mt-2">Exporting...</div>
+</div>
 
 
 <!-- On page load, HTMX triggers GET request to 'render_table'

--- a/ftva_lab_data/templates/search_results.html
+++ b/ftva_lab_data/templates/search_results.html
@@ -49,7 +49,14 @@
         </select>
         <button type="submit" class="btn btn-sm btn-primary">Assign Selected</button>
     </form>
-    {% endif %}    
+    {% endif %}
+    <form method="get" action="{% url 'export_search_results' %}" class="mb-3">
+        <input type="hidden" name="search" value="{{ search }}">
+        <input type="hidden" name="search_column" value="{{ search_column }}">
+        <button type="submit" class="btn btn-outline-success">
+            Export to Excel
+        </button>
+    </form>
 </div> 
 
 

--- a/ftva_lab_data/tests.py
+++ b/ftva_lab_data/tests.py
@@ -729,12 +729,6 @@ class DataExportTestCase(TestCase):
         data_dicts = [row.__dict__ for row in self.rows]
         export_data = format_data_for_export(data_dicts)
 
-        # Check that the carrier_a_location column is next to the carrier_a column
-        self.assertIn("carrier_a", export_data.columns)
-        self.assertIn("carrier_a_location", export_data.columns)
-        carrier_a_index = export_data.columns.get_loc("carrier_a")
-        carrier_a_location_index = export_data.columns.get_loc("carrier_a_location")
-        self.assertEqual(carrier_a_index + 1, carrier_a_location_index)
         # Test that the assigned user's full name is formatted correctly
         self.assertIn("Example User", export_data["assigned_user"].values)
         # Check that the Statuses are concatenated correctly

--- a/ftva_lab_data/urls.py
+++ b/ftva_lab_data/urls.py
@@ -8,4 +8,9 @@ urlpatterns = [
     path("edit_item/<int:item_id>/", views.edit_item, name="edit_item"),
     path("view_item/<int:item_id>/", views.view_item, name="view_item"),
     path("assign/", views.assign_to_user, name="assign_to_user"),
+    path(
+        "export_search_results/",
+        views.export_search_results,
+        name="export_search_results",
+    ),
 ]

--- a/ftva_lab_data/views.py
+++ b/ftva_lab_data/views.py
@@ -7,6 +7,7 @@ from django.http import HttpRequest, HttpResponse
 from django.contrib.auth import get_user_model
 from django.template.loader import render_to_string
 import pandas as pd
+import io
 
 from .forms import ItemForm
 from .models import SheetImport
@@ -25,8 +26,9 @@ from .views_utils import (
     "ftva_lab_data.add_sheetimport",
     raise_exception=True,
 )
-def add_item(request):
+def add_item(request: HttpRequest) -> HttpResponse:
     """Add a new item to the database.
+
     :param request: The HTTP request object.
     :return: Rendered template for adding an item.
     """
@@ -62,8 +64,9 @@ def add_item(request):
     "ftva_lab_data.change_sheetimport",
     raise_exception=True,
 )
-def edit_item(request, item_id):
+def edit_item(request: HttpRequest, item_id: int) -> HttpResponse:
     """Edit an existing item in the database.
+
     :param request: The HTTP request object.
     :param item_id: The ID of the item to edit.
     :return: Rendered template for editing an item.
@@ -112,7 +115,7 @@ def edit_item(request, item_id):
 
 
 @login_required
-def view_item(request, item_id):
+def view_item(request: HttpRequest, item_id: int) -> HttpResponse:
     """View details of a specific item.
 
     :param request: The HTTP request object.
@@ -293,11 +296,44 @@ def export_search_results(request: HttpRequest) -> HttpResponse:
 
     # Include all fields in the DataFrame, even if they are not displayed
     data_dicts = [row.__dict__ for row in rows]
-    # Remove the '_state' field added by Django
+    # Add and remove fields to match the expected output format:
+    # Add a column for Status (ManyToMany relationship with Status model),
+    # replace the Assigned User ID with assigned_user_full_name property, and
+    # remove the '_state' field added by Django.
     for data_dict in data_dicts:
+        current_item = SheetImport.objects.get(id=data_dict["id"])
+        # Add status display values as a concatenated string
+        statuses = current_item.status.values_list("status", flat=True)
+        data_dict["status"] = ", ".join(statuses) if statuses else ""
+        # Replace the assigned_user_id with the full name
+        assigned_user_id = data_dict.pop("assigned_user_id")
+        if assigned_user_id is not None:
+            assigned_user_full_name = current_item.assigned_user_full_name
+            data_dict["assigned_user"] = assigned_user_full_name
+        else:
+            data_dict["assigned_user"] = ""
+        # Remove the '_state' field added by Django
         data_dict.pop("_state", None)
+
     # Convert rows to DataFrame for exporting
     df = pd.DataFrame(data_dicts)
+
+    # Reorder carrier_a_location and carrier_b_location to be next to carrier_a and carrier_b
+    carrier_a_index = df.columns.get_loc("carrier_a")
+    carrier_a_location_index = df.columns.get_loc("carrier_a_location")
+    # Move carrier_a_location and carrier_b_location next to their respective carriers
+    if carrier_a_location_index > carrier_a_index + 1:
+        # Move carrier_a_location to the right of carrier_a
+        df.insert(
+            carrier_a_index + 1, "carrier_a_location", df.pop("carrier_a_location")
+        )
+    carrier_b_index = df.columns.get_loc("carrier_b")
+    carrier_b_location_index = df.columns.get_loc("carrier_b_location")
+    if carrier_b_location_index > carrier_b_index + 1:
+        # Move carrier_b_location to the right of carrier_b
+        df.insert(
+            carrier_b_index + 1, "carrier_b_location", df.pop("carrier_b_location")
+        )
 
     filename_base = "FTVA_DL_search_results"
     timestamp = pd.Timestamp.now().strftime("%Y%m%d_%H%M%S")
@@ -307,6 +343,13 @@ def export_search_results(request: HttpRequest) -> HttpResponse:
         content_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
     )
     response["Content-Disposition"] = f"attachment; filename={filename}"
-    with pd.ExcelWriter(response, engine="xlsxwriter") as writer:
+    # Create buffer in memory to hold the Excel file,
+    # because ExcelWriter expects a file-like object
+    buffer = io.BytesIO()
+    with pd.ExcelWriter(buffer, engine="xlsxwriter") as writer:
         df.to_excel(writer, index=False)
+    # Return to the start of the buffer so we can read from it
+    buffer.seek(0)
+    # Write the buffer content to the response
+    response.write(buffer.read())
     return response

--- a/ftva_lab_data/views.py
+++ b/ftva_lab_data/views.py
@@ -6,7 +6,7 @@ from django.core.paginator import Paginator
 from django.http import HttpRequest, HttpResponse
 from django.contrib.auth import get_user_model
 from django.template.loader import render_to_string
-
+import pandas as pd
 
 from .forms import ItemForm
 from .models import SheetImport
@@ -242,3 +242,35 @@ def assign_to_user(request: HttpRequest) -> HttpResponse:
 
     # Otherwise, do a normal redirect
     return redirect("search_results")
+
+
+@login_required
+def export_search_results(request: HttpRequest) -> HttpResponse:
+    """Exports search results to an Excel file."""
+    search = request.GET.get("search", "")
+    search_column = request.GET.get("search_column", "")
+    search_fields = (
+        [search_column] if search_column else [field for field, _ in COLUMNS]
+    )
+
+    rows = get_search_result_items(search, search_fields)
+
+    # Include all fields in the DataFrame, even if they are not displayed
+    data_dicts = [row.__dict__ for row in rows]
+    # Remove the '_state' field added by Django
+    for data_dict in data_dicts:
+        data_dict.pop("_state", None)
+    # Convert rows to DataFrame for exporting
+    df = pd.DataFrame(data_dicts)
+
+    filename_base = "FTVA_DL_search_results"
+    timestamp = pd.Timestamp.now().strftime("%Y%m%d_%H%M%S")
+    filename = f"{filename_base}_{timestamp}.xlsx"
+
+    response = HttpResponse(
+        content_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    )
+    response["Content-Disposition"] = f"attachment; filename={filename}"
+    with pd.ExcelWriter(response, engine="xlsxwriter") as writer:
+        df.to_excel(writer, index=False)
+    return response

--- a/ftva_lab_data/views.py
+++ b/ftva_lab_data/views.py
@@ -26,6 +26,10 @@ from .views_utils import (
     raise_exception=True,
 )
 def add_item(request):
+    """Add a new item to the database.
+    :param request: The HTTP request object.
+    :return: Rendered template for adding an item.
+    """
     # context values to be passed to the add_edit_item template
     add_item_context = {
         "form": ItemForm(),
@@ -59,6 +63,11 @@ def add_item(request):
     raise_exception=True,
 )
 def edit_item(request, item_id):
+    """Edit an existing item in the database.
+    :param request: The HTTP request object.
+    :param item_id: The ID of the item to edit.
+    :return: Rendered template for editing an item.
+    """
     # Retrieve the item to edit
     item = SheetImport.objects.get(id=item_id)
     # Get search params from GET or POST, to be used to help navigate back
@@ -104,6 +113,12 @@ def edit_item(request, item_id):
 
 @login_required
 def view_item(request, item_id):
+    """View details of a specific item.
+
+    :param request: The HTTP request object.
+    :param item_id: The ID of the item to view.
+    :return: Rendered template for viewing an item.
+    """
     # Retrieve the item to view
     item = SheetImport.objects.get(id=item_id)
     # For easier parsing in the template, separate attributes into dictionaries
@@ -122,6 +137,15 @@ def view_item(request, item_id):
 
 @login_required
 def search_results(request: HttpRequest) -> HttpResponse:
+    """Render search results page.
+    This view handles the initial rendering of the search results page,
+    including the user list and search parameters, but not the actual search
+    results table.
+
+    :param request: The HTTP request object.
+    :return: Rendered template for search results.
+    """
+
     users = get_user_model().objects.all().order_by("username")
     # Pass search params from GET to template context,
     # so we can consistently render the results table after navigation
@@ -143,7 +167,10 @@ def render_search_results_table(request: HttpRequest) -> HttpResponse:
     """Handles search and pagination of table.
 
     Search can either be column-specific, determined by dropdown,
-    or broad, CTRL-F-style across all fields
+    or broad, CTRL-F-style across all fields.
+
+    :param request: The HTTP request object.
+    :return: Rendered HTML for the search results table.
     """
     search = request.GET.get("search", "")
     search_column = request.GET.get("search_column", "")
@@ -209,7 +236,12 @@ def render_search_results_table(request: HttpRequest) -> HttpResponse:
     raise_exception=True,
 )
 def assign_to_user(request: HttpRequest) -> HttpResponse:
-    """Assigns a SheetImport item to a user."""
+    """Assigns a SheetImport item to a user.
+
+    :param request: The HTTP request object.
+    :return: Redirects to search results,
+        or returns updated table HTML for HTMX requests.
+    """
     ids = request.POST.get("ids", "").split(",")
     user_id = request.POST.get("user_id")
     if ids and user_id:
@@ -246,7 +278,11 @@ def assign_to_user(request: HttpRequest) -> HttpResponse:
 
 @login_required
 def export_search_results(request: HttpRequest) -> HttpResponse:
-    """Exports search results to an Excel file."""
+    """Exports search results to an Excel file.
+
+    :param request: The HTTP request object.
+    :return: An HTTP response with the Excel file attachment.
+    """
     search = request.GET.get("search", "")
     search_column = request.GET.get("search_column", "")
     search_fields = (

--- a/ftva_lab_data/views_utils.py
+++ b/ftva_lab_data/views_utils.py
@@ -3,6 +3,7 @@ from django.db.models import Model, Q
 from django.db.models.query import QuerySet
 from .models import SheetImport
 from .forms import ItemForm
+import pandas as pd
 
 
 # Recursive implementation adapted from:
@@ -21,6 +22,10 @@ def get_field_value(obj: Model, field: str) -> Any:
 
     Returns the value of the field, or an empty string if the field does not exist
     or is None.
+
+    :param obj: The model instance to get the field value from.
+    :param field: The field name, which can include nested fields separated by "__".
+    :return: The value of the field, or an empty string if the field does not exist or is None.
     """
     # Special case for status field, which is a ManyToMany field
     if field == "status":
@@ -36,7 +41,13 @@ def get_field_value(obj: Model, field: str) -> Any:
 
 def get_item_display_dicts(item: SheetImport) -> dict[str, Any]:
     """Returns a dictionary of dictionaries. Each top-level dict represents a display section for
-    the view_item.html template."""
+    the view_item.html template.
+
+    :param item: The SheetImport object to get the display data for.
+    :return: A dictionary with keys "header_info", "storage_info", "file_info",
+    "inventory_info", and "advanced_info". Each key maps to a dictionary of field names and values
+    for that section.
+    """
     header_info = {
         "file_name": item.file_name,
         "title": item.title,
@@ -112,7 +123,11 @@ def get_item_display_dicts(item: SheetImport) -> dict[str, Any]:
 
 def get_add_edit_item_fields(form: ItemForm) -> dict[str, list[str]]:
     """Returns a dict with keys "basic_fields" and "advanced_fields",
-    each containing a list of field names to be used in the add/edit item form."""
+    each containing a list of field names to be used in the add/edit item form.
+
+    :param form: The ItemForm instance to get the fields from.
+    :return: A dictionary with keys "basic_fields" and "advanced_fields".
+    """
     basic_fields = [
         "status",
         "hard_drive_name",
@@ -136,6 +151,11 @@ def get_search_result_items(search: str, search_fields: list[str]) -> QuerySet:
     in ftva_lab_data.table_config.
 
     Returns a QuerySet of SheetImport objects matching the search.
+
+    :param search: The search term to look for in the specified fields.
+    :param search_fields: A list of field names to search in. These should be valid
+    field names of the SheetImport model or its related models.
+    :return: A QuerySet of SheetImport objects that match the search criteria.
     """
 
     # Use all() here instead of only(specific fields) to allow separation
@@ -193,6 +213,10 @@ def get_search_result_data(
     accessed for links.
     `data` simplifies template output, allowing `row[field]` to be accessed instead of specifying
     each field explicitly.
+
+    :param item_list: A QuerySet of SheetImport objects to process.
+    :param display_fields: A list of field names to include in the data dicts.
+    :return: A list of dictionaries, each representing a row in the table.
     """
 
     rows = [
@@ -214,3 +238,52 @@ def get_items_per_page_options() -> list[int]:
     """
 
     return [10, 20, 50, 100]
+
+
+def format_data_for_export(data_dicts: list[dict[str, Any]]) -> pd.DataFrame:
+    """Formats a list of dictionaries of SheetImport data for export to Excel.
+
+    :param data_dicts: A list of dictionaries, each representing a row of data.
+    :return: A pandas DataFrame with the formatted data.
+    """
+
+    # Add and remove fields to match the expected output format:
+    # Add a column for Status (ManyToMany relationship with Status model),
+    # replace the Assigned User ID with assigned_user_full_name property, and
+    # remove the '_state' field added by Django.
+    for data_dict in data_dicts:
+        current_item = SheetImport.objects.get(id=data_dict["id"])
+        # Add status display values as a concatenated string
+        statuses = current_item.status.values_list("status", flat=True)
+        data_dict["status"] = ", ".join(statuses) if statuses else ""
+        # Replace the assigned_user_id with the full name
+        assigned_user_id = data_dict.pop("assigned_user_id")
+        if assigned_user_id is not None:
+            assigned_user_full_name = current_item.assigned_user_full_name
+            data_dict["assigned_user"] = assigned_user_full_name
+        else:
+            data_dict["assigned_user"] = ""
+        # Remove the '_state' field added by Django
+        data_dict.pop("_state", None)
+
+    # Convert rows to DataFrame for exporting
+    df = pd.DataFrame(data_dicts)
+
+    # Reorder carrier_a_location and carrier_b_location to be next to carrier_a and carrier_b
+    carrier_a_index = df.columns.get_loc("carrier_a")
+    carrier_a_location_index = df.columns.get_loc("carrier_a_location")
+    # Move carrier_a_location and carrier_b_location next to their respective carriers
+    if carrier_a_location_index > carrier_a_index + 1:
+        # Move carrier_a_location to the right of carrier_a
+        df.insert(
+            carrier_a_index + 1, "carrier_a_location", df.pop("carrier_a_location")
+        )
+    carrier_b_index = df.columns.get_loc("carrier_b")
+    carrier_b_location_index = df.columns.get_loc("carrier_b_location")
+    if carrier_b_location_index > carrier_b_index + 1:
+        # Move carrier_b_location to the right of carrier_b
+        df.insert(
+            carrier_b_index + 1, "carrier_b_location", df.pop("carrier_b_location")
+        )
+
+    return df

--- a/ftva_lab_data/views_utils.py
+++ b/ftva_lab_data/views_utils.py
@@ -269,21 +269,4 @@ def format_data_for_export(data_dicts: list[dict[str, Any]]) -> pd.DataFrame:
     # Convert rows to DataFrame for exporting
     df = pd.DataFrame(data_dicts)
 
-    # Reorder carrier_a_location and carrier_b_location to be next to carrier_a and carrier_b
-    carrier_a_index = df.columns.get_loc("carrier_a")
-    carrier_a_location_index = df.columns.get_loc("carrier_a_location")
-    # Move carrier_a_location and carrier_b_location next to their respective carriers
-    if carrier_a_location_index > carrier_a_index + 1:
-        # Move carrier_a_location to the right of carrier_a
-        df.insert(
-            carrier_a_index + 1, "carrier_a_location", df.pop("carrier_a_location")
-        )
-    carrier_b_index = df.columns.get_loc("carrier_b")
-    carrier_b_location_index = df.columns.get_loc("carrier_b_location")
-    if carrier_b_location_index > carrier_b_index + 1:
-        # Move carrier_b_location to the right of carrier_b
-        df.insert(
-            carrier_b_index + 1, "carrier_b_location", df.pop("carrier_b_location")
-        )
-
     return df

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ gunicorn==23.0.0
 whitenoise==6.9.0
 pandas==2.2.3
 openpyxl==3.1.5
+xlsxwriter==3.2.5

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -109,3 +109,20 @@ document.addEventListener("input", function (e) {
     syncExportFormFields();
   }
 });
+
+// Handle export button click - add spinner and submit export form
+document.addEventListener("DOMContentLoaded", function () {
+  const exportBtn = document.getElementById("export-button");
+  const exportForm = document.getElementById("export-form");
+  const spinner = document.getElementById("export-spinner");
+  if (exportBtn && exportForm && spinner) {
+    exportBtn.addEventListener("click", function () {
+      spinner.style.display = "block";
+      exportForm.submit();
+      // Hide spinner after a delay?
+      // setTimeout(() => {
+      //  spinner.style.display = "none";
+      //}, 5000);
+    });
+  }
+});

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -18,7 +18,7 @@ function clearSearchInput() {
   htmx.trigger(input, "clear");
 }
 
-// Utility: Set or update a hidden input in a form
+// Utility function: Set or update a hidden input in a form
 function setOrUpdate(form, name, value) {
   let el = form.querySelector(`input[name="${name}"]`);
   if (!el) {
@@ -82,8 +82,6 @@ document.addEventListener("DOMContentLoaded", function () {
   };
 });
 // Sync export form fields with search inputs
-// This ensures that the export form always has the current search parameters
-// when the user clicks the export button.
 // This is necessary because the export form is a separate form and does not
 // automatically get updated by HTMX when the search form changes.
 function syncExportFormFields() {
@@ -91,7 +89,6 @@ function syncExportFormFields() {
   const searchColumn = document.querySelector('select[name="search_column"]');
   const exportForm = document.querySelector('form[action$="export_search_results/"]');
   if (!exportForm) return;
-
 
   setOrUpdate(exportForm, "search", searchInput ? searchInput.value : "");
   setOrUpdate(exportForm, "search_column", searchColumn ? searchColumn.value : "");

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -119,7 +119,7 @@ document.addEventListener("DOMContentLoaded", function () {
     exportBtn.addEventListener("click", function () {
       spinner.style.display = "block";
       exportForm.submit();
-      // Hide spinner after a delay?      
+      // Hide spinner after a constant delay
       setTimeout(() => {
       spinner.style.display = "none";
       }, 60000);

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -119,10 +119,10 @@ document.addEventListener("DOMContentLoaded", function () {
     exportBtn.addEventListener("click", function () {
       spinner.style.display = "block";
       exportForm.submit();
-      // Hide spinner after a delay?
-      // setTimeout(() => {
-      //  spinner.style.display = "none";
-      //}, 5000);
+      // Hide spinner after a delay?      
+      setTimeout(() => {
+      spinner.style.display = "none";
+      }, 60000);
     });
   }
 });

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -119,10 +119,10 @@ document.addEventListener("DOMContentLoaded", function () {
     exportBtn.addEventListener("click", function () {
       spinner.style.display = "block";
       exportForm.submit();
-      // Hide spinner after a constant delay
+      // Hide spinner after a constant 10s delay
       setTimeout(() => {
       spinner.style.display = "none";
-      }, 60000);
+      }, 10000);
     });
   }
 });

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -18,6 +18,18 @@ function clearSearchInput() {
   htmx.trigger(input, "clear");
 }
 
+// Utility: Set or update a hidden input in a form
+function setOrUpdate(form, name, value) {
+  let el = form.querySelector(`input[name="${name}"]`);
+  if (!el) {
+    el = document.createElement("input");
+    el.type = "hidden";
+    el.name = name;
+    form.appendChild(el);
+  }
+  el.value = value || "";
+}
+
 document.addEventListener("htmx:afterSwap", function (e) {
   const selectAll = document.getElementById("select-all-checkbox");
   if (selectAll) {
@@ -59,23 +71,44 @@ document.addEventListener("DOMContentLoaded", function () {
       const search_column = document.querySelector('select[name="search_column"]');
       const page = document.querySelector("#current-page")?.value;
 
-      function setOrUpdate(name, value) {
-        let el = this.querySelector(`input[name="${name}"]`);
-        if (!el) {
-          el = document.createElement("input");
-          el.type = "hidden";
-          el.name = name;
-          this.appendChild(el);
-        }
-        el.value = value || "";
-      }
-      setOrUpdate.call(this, "search", search ? search.value : "");
-      setOrUpdate.call(
+      setOrUpdate(this, "search", search ? search.value : "");
+      setOrUpdate(
         this,
         "search_column",
         search_column ? search_column.value : ""
       );
-      setOrUpdate.call(this, "page", page || "");
+      setOrUpdate(this, "page", page || "");
     });
   };
+});
+// Sync export form fields with search inputs
+// This ensures that the export form always has the current search parameters
+// when the user clicks the export button.
+// This is necessary because the export form is a separate form and does not
+// automatically get updated by HTMX when the search form changes.
+function syncExportFormFields() {
+  const searchInput = document.querySelector('input[name="search"]');
+  const searchColumn = document.querySelector('select[name="search_column"]');
+  const exportForm = document.querySelector('form[action$="export_search_results/"]');
+  if (!exportForm) return;
+
+
+  setOrUpdate(exportForm, "search", searchInput ? searchInput.value : "");
+  setOrUpdate(exportForm, "search_column", searchColumn ? searchColumn.value : "");
+}
+
+// Sync on page load
+document.addEventListener("DOMContentLoaded", syncExportFormFields);
+
+// Sync after any HTMX swap (table/search form updates)
+document.addEventListener("htmx:afterSwap", syncExportFormFields);
+
+// Sync on search form input changes
+document.addEventListener("input", function (e) {
+  if (
+    e.target.matches('input[name="search"]') ||
+    e.target.matches('select[name="search_column"]')
+  ) {
+    syncExportFormFields();
+  }
 });


### PR DESCRIPTION
Implements [SYS-1880](https://uclalibrary.atlassian.net/browse/SYS-1880)

Adds an "Export to Excel" button, visible to all signed-in users, that will export the current set of search results to an Excel file called `FTVA_DL_search_results_{timestamp}.xlsx`. The export file contains all fields associated with each `SheetImport` object, not just those visible on the search results screen.

Includes minor refactoring of `main.js` to re-use the `setOrUpdate()` function written for user assignment, and updated docstrings throughout `views.py` to use the new Sphinx markup style.

This PR adds `xlsxwriter` as a new dependency in `requirements.txt`. Rebuild the Django container to install this.

<img width="1095" alt="image" src="https://github.com/user-attachments/assets/7824301e-71bc-4bb0-9e72-8b9974768da9" />


[SYS-1880]: https://uclalibrary.atlassian.net/browse/SYS-1880?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ