### PR TITLE
SYS-1879: add records per page control

### DIFF
--- a/ftva_lab_data/templates/partials/pagination_controls.html
+++ b/ftva_lab_data/templates/partials/pagination_controls.html
@@ -1,11 +1,16 @@
 <div class="row">
+    {% comment %}This conditional controls whether the two <div> elements
+    on either side of the main pagination controls are shown or not,
+    as this partial is used both above and below the table,
+    and we only want to show the additional controls above the table.
+    {% endcomment %}
     {% if show_auxiliary_controls %}
         <div class="col-2 d-flex align-items-center gap-2">
             <select
                 name="items_per_page"
                 class="form-select form-select-md"
                 style="width: fit-content;"
-                hx-get="{% url 'render_table' %}"
+                hx-get="{% url 'render_table' %}?search={{ search }}&search_column={{ search_column }}"
                 hx-target="#table-container"    
             >
                 {% for option in items_per_page_options %}
@@ -46,7 +51,8 @@
             Next
         </button>
     </div>
-
+    
+    {% comment %}See comment above regarding this conditional.{% endcomment %}
     {% if show_auxiliary_controls %}
         <div class="col-2">
             <!-- Added to keep row balanced and main pagination controls centered.

--- a/ftva_lab_data/templates/partials/search_results_table.html
+++ b/ftva_lab_data/templates/partials/search_results_table.html
@@ -1,3 +1,7 @@
+{% comment %}The `show_auxiliary_controls` attribute controls whether or not
+to render <div> elements for controls on either side of the main pagination controls.
+See comment on partial as well.
+{% endcomment %}
 {% include "partials/pagination_controls.html" with show_auxiliary_controls=True %}
 
 <table class="table table-hover" style="table-layout: fixed;">
@@ -79,7 +83,8 @@
     </tbody>
 </table>
 
-{% include "partials/pagination_controls.html" %}
+{% comment %}See comment above regarding `show_auxiliary_controls` attribute.{% endcomment %}
+{% include "partials/pagination_controls.html" with show_auxiliary_controls=False %}
 
 <!-- Hidden input to store the current page number for HTMX requests -->
 <!-- Used to maintain state after POST requests to assign items to users -->

--- a/ftva_lab_data/tests.py
+++ b/ftva_lab_data/tests.py
@@ -20,6 +20,7 @@ from ftva_lab_data.views_utils import (
     get_field_value,
     get_item_display_dicts,
     get_search_result_items,
+    get_items_per_page_options,
 )
 from ftva_lab_data.table_config import COLUMNS
 
@@ -201,7 +202,7 @@ class TablePaginationTestCase(TestCase):
         SheetImport.objects.all().delete()
 
         # Create enough SheetImport objects to require pagination
-        # (i.e. more than the default page size of 10)
+        # (i.e. more than the maximum page size allowed by `items_per_page`)
         for i in range(150):
             SheetImport.objects.create(file_name=f"test_file_{i}", id=i)
         # Create SheetImport objects with different filenames
@@ -239,18 +240,18 @@ class TablePaginationTestCase(TestCase):
         self.assertIn("test_file_10", page_2_content)
         self.assertNotIn("unique_file_1", page_2_content)
 
-    def test_items_per_page_control(self):
+    def test_valid_items_per_page_options(self):
         url = reverse("render_table")
-        test_values = ["", 10, 20, 50, 100, "foobar"]
+        items_per_page_options = get_items_per_page_options()
 
-        # Test that given various values in the request parameters,
+        # Test that for each option from `get_items_per_page_options()`,
         # the per page value in the paginator object
         # and in the session store stay in sync.
         # So long as they are in sync, the table should render correctly
         # and the per page setting should persist within the session.
-        for value in test_values:
-            with self.subTest(value=value):
-                response = self.client.get(url, {"items_per_page": value})
+        for option in items_per_page_options:
+            with self.subTest(option=option):
+                response = self.client.get(url, {"items_per_page": option})
 
                 paginator_per_page = response.context.get("page_obj").paginator.per_page
                 session_per_page = response.context.get("request").session[
@@ -258,6 +259,31 @@ class TablePaginationTestCase(TestCase):
                 ]
 
                 self.assertEqual(paginator_per_page, session_per_page)
+
+    def test_invalid_items_per_page_options(self):
+        url = reverse("render_table")
+
+        # The view expects `items_per_page` to be an integer,
+        # so this tests an empty string and a boolean
+        # to make sure they are handled correctly by the view
+        # and fall back to the default per-page option.
+        invalid_options = ["", True]
+
+        for option in invalid_options:
+            with self.subTest(option=option):
+                response = self.client.get(url, {"items_per_page": option})
+
+                paginator_per_page = response.context.get("page_obj").paginator.per_page
+                session_per_page = response.context.get("request").session[
+                    "items_per_page"
+                ]
+                # The default per-page option is the first item
+                # in the list returned by `items_per_page_options`.
+                default_per_page = get_items_per_page_options()[0]
+                # The per-page values in both the paginator and session objects
+                # should fall back to the default when give non-int values.
+                self.assertEqual(paginator_per_page, default_per_page)
+                self.assertEqual(session_per_page, default_per_page)
 
 
 class HistoryModelTestCase(TestCase):

--- a/ftva_lab_data/views.py
+++ b/ftva_lab_data/views.py
@@ -16,6 +16,7 @@ from .views_utils import (
     get_add_edit_item_fields,
     get_search_result_data,
     get_search_result_items,
+    get_items_per_page_options,
 )
 
 
@@ -156,7 +157,7 @@ def render_search_results_table(request: HttpRequest) -> HttpResponse:
 
     items = get_search_result_items(search, search_fields)
 
-    items_per_page_options = [10, 20, 50, 100]  # hard-coded here for now
+    items_per_page_options = get_items_per_page_options()
     default_per_page = items_per_page_options[0]
     # If `items_per_page` comes from request
     # overwrite value in session object

--- a/ftva_lab_data/views_utils.py
+++ b/ftva_lab_data/views_utils.py
@@ -205,3 +205,13 @@ def get_search_result_data(
     ]
 
     return rows
+
+
+def get_items_per_page_options() -> list[int]:
+    """Returns options to use on the `items_per_page` control
+    in `partials/pagination_controls.html`.
+
+    :return list[int]: A list of integers representing per-page options.
+    """
+
+    return [10, 20, 50, 100]


### PR DESCRIPTION
Implements [SYS-1879](https://uclalibrary.atlassian.net/browse/SYS-1879)

### Acceptance criteria
- ✅ User can set number of search result records per page
- ✅ This should persist across searches, so user has to set it only once per session.
    - ❌ It does not need to persist across sessions, via user-specific settings.

### Details
I changed `partials\pagination_controls.html` into a row with three columns, then added the controls in the left-most column of the row. The user select from a drop-down of per-page options. For now, this list is hard-coded in `views.py`.

The per-page selection should persist when the user refreshes the page or navigates away from the table to the `add_item` or `edit_item` routes. As the user pages through the table, the setting should persist, as it should when a search term is entered.

One thing to note is that when the per-page selection changes, the pagination recalculates, and so the table resets to page 1. This is similar to the behavior when the search inputs change.

### Testing
I added one test to the `TablePaginationTestCase`. The test demonstrates that given various request parameters, the `per_page` value on the `Paginator` object, from which the table gets its pages, and the `items_per_page` value in the session store stay in sync. I could add a test to actually validate the count of `<tr>` sub-strings in the actual response content is as expected; let me know if you think that's worthwhile.

![screencap](https://github.com/user-attachments/assets/ab81da6d-bbb1-40ab-98ca-21dfd757db5d)


[SYS-1879]: https://uclalibrary.atlassian.net/browse/SYS-1879?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ