### PR TITLE
SYS-1881: Add status and move field

### DIFF
--- a/ftva_lab_data/fixtures/item_statuses.json
+++ b/ftva_lab_data/fixtures/item_statuses.json
@@ -47,5 +47,12 @@
     "fields": {
       "status": "Deletion requested"
     }
+  },
+  {
+    "model": "ftva_lab_data.itemstatus",
+    "pk": 8,
+    "fields": {
+      "status": "Needs review"
+    }
   }
 ]

--- a/ftva_lab_data/views_utils.py
+++ b/ftva_lab_data/views_utils.py
@@ -120,7 +120,6 @@ def get_add_edit_item_fields(form: ItemForm) -> dict[str, list[str]]:
         "carrier_a_location",
         "carrier_b",
         "carrier_b_location",
-        "hard_drive_barcode_id",
         "file_folder_name",
         "sub_folder_name",
         "file_name",

--- a/ftva_lab_data/views_utils.py
+++ b/ftva_lab_data/views_utils.py
@@ -49,7 +49,6 @@ def get_item_display_dicts(item: SheetImport) -> dict[str, Any]:
         "Carrier A Location": item.carrier_a_location,
         "Carrier B": item.carrier_b,
         "Carrier B Location": item.carrier_b_location,
-        "Hard Drive Barcode ID": item.hard_drive_barcode_id,
     }
     file_info = {
         "File/Folder Name": item.file_folder_name,
@@ -97,6 +96,7 @@ def get_item_display_dicts(item: SheetImport) -> dict[str, Any]:
         "Security Data Encrypted": item.security_data_encrypted,
         "Migration or Preservation Record": item.migration_or_preservation_record,
         "Hard Drive Location": item.hard_drive_location,
+        "Hard Drive Barcode ID": item.hard_drive_barcode_id,
         "Date Job Started": item.date_job_started,
         "Date Job Completed": item.date_job_completed,
         "General Entry Cataloged By": item.general_entry_cataloged_by,


### PR DESCRIPTION
Implements [SYS-1881](https://uclalibrary.atlassian.net/browse/SYS-1881) (combined with [SYS-1882](https://uclalibrary.atlassian.net/browse/SYS-1882))

### Acceptance criteria
- ✅ A new status, “Needs review”, is added
- ✅ “Hard Drive Barcode ID” is moved to Advanced Fields

### Discussion
I went ahead and combined these two tickets, as SYS-1881 is a blocker for [SYS-1883](https://uclalibrary.atlassian.net/browse/SYS-1883). I simply added a status item to the `item_statuses` fixture and removed `hard_drive_barcode_id` from the basic fields list in the `view_utils` function that returns the fields split up into basic and advanced. Seems to have done the trick ⬇️ 

<img width="1431" alt="Screenshot 2025-06-26 at 5 26 35 PM" src="https://github.com/user-attachments/assets/3efc285f-12f8-4b41-9776-279fb11f8142" />


[SYS-1881]: https://uclalibrary.atlassian.net/browse/SYS-1881?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SYS-1882]: https://uclalibrary.atlassian.net/browse/SYS-1882?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SYS-1883]: https://uclalibrary.atlassian.net/browse/SYS-1883?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ