### PR TITLE
SYS-1888: Fix required fields not displaying data

### DIFF
--- a/ftva_lab_data/templates/add_edit_item.html
+++ b/ftva_lab_data/templates/add_edit_item.html
@@ -42,7 +42,7 @@
                                 data-bs-toggle="tooltip"
                                 title="Required field"
                             >{{ field.label }}</label>
-                            <input type="text" class="form-control" id="id_file_name" placeholder="{{ field.label }}" value="{{ field.value }}" required>
+                            <input type="text" class="form-control" id="id_file_name" placeholder="{{ field.label }}" value="{{ field.value|default:'' }}" required>
                         </div>
                     {% else %}
                         {% bootstrap_field field %}
@@ -68,7 +68,7 @@
                                 data-bs-toggle="tooltip"
                                 title="Required field"
                             >{{ field.label }}</label>
-                            <input type="text" class="form-control" id="id_file_name" placeholder="{{ field.label }}" value="{{ field.value }}" required>
+                            <input type="text" class="form-control" id="id_file_name" placeholder="{{ field.label }}" value="{{ field.value|default:'' }}" required>
                         </div>
                     {% else %}
                         {% bootstrap_field field %}

--- a/ftva_lab_data/templates/add_edit_item.html
+++ b/ftva_lab_data/templates/add_edit_item.html
@@ -42,7 +42,7 @@
                                 data-bs-toggle="tooltip"
                                 title="Required field"
                             >{{ field.label }}</label>
-                            <input type="text" class="form-control" id="id_file_name" placeholder="{{ field.label }}" required>
+                            <input type="text" class="form-control" id="id_file_name" placeholder="{{ field.label }}" value="{{ field.value }}" required>
                         </div>
                     {% else %}
                         {% bootstrap_field field %}
@@ -68,7 +68,7 @@
                                 data-bs-toggle="tooltip"
                                 title="Required field"
                             >{{ field.label }}</label>
-                            <input type="text" class="form-control" id="id_file_name" placeholder="{{ field.label }}" required>
+                            <input type="text" class="form-control" id="id_file_name" placeholder="{{ field.label }}" value="{{ field.value }}" required>
                         </div>
                     {% else %}
                         {% bootstrap_field field %}


### PR DESCRIPTION
Fixes [SYS-1888](https://uclalibrary.atlassian.net/browse/SYS-1888)

### Problem
The `<input>` elements used for required fields in the `add_edit_item.html` template were missing a `value` attribute.

### Solution
Adding the value attribute and setting it to the value of the field object in the current context (with a default of an empty string) did the trick (see screenshot below).

![image](https://github.com/user-attachments/assets/dbbe9144-7484-4379-a8fe-e36c25a1625c)

### Note
This does not appear to resolve [SYS-1887](https://uclalibrary.atlassian.net/browse/SYS-1887). Though the correct value from the database now displays in the "File name" input field, I cannot save inputs to any other fields.

In my browser console, I see the following error related to JavaScript:
> Uncaught TypeError: can't access property "onsubmit", document.getElementById(...) is null
    <anonymous> http://localhost:8000/static/js/main.js:21
main.js:21:10

The relevant JavaScript method in `main.js` that's throwing the error is:
> document.getElementById("assigned-users-form")