### PR TITLE
SYS-1889: Add tests for required form fields

### DIFF
--- a/ftva_lab_data/tests.py
+++ b/ftva_lab_data/tests.py
@@ -694,7 +694,7 @@ class RequiredFormFieldTestCase(TestCase):
         # file_name is currently the only required field.
         form_data = {"file_name": "My new file"}
         form = ItemForm(data=form_data)
-        # Missing data means form is not valid.
+        # Form should be valid when file_name has a value.
         self.assertTrue(form.is_valid())
 
     def test_having_required_field_allows_save(self):


### PR DESCRIPTION
Implements [SYS-1889](asd).  Not tagged for deployment; this is internal code which will go in a later release.

This PR adds `RequiredFormFieldTestCase()`, with 4 tests to confirm that `ItemForm()` can't be validated or saved unless there is a value provided for `file_name`, currently the only required field on the `SheetImport` model.  I chose to test this directly against the form, without going through the view(s), as those have more relevant tests covering permissions.

It also fixes and re-enables `AddEditItemTestCase.test_required_fields_display_with_indicator()`, which broke and was skipped in #38 .

There should now be 42 tests, all passing, none skipped.


[SYS-1889]: https://uclalibrary.atlassian.net/browse/SYS-1889?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ