### PR TITLE
SYS-1892: Sync button spinner with request

### DIFF
--- a/ftva_lab_data/templates/search_results.html
+++ b/ftva_lab_data/templates/search_results.html
@@ -14,7 +14,7 @@
     <!-- HTMX will listen for triggers from enclosed controls,
     then issue GET requests to 'render_table' URL
     and replace content of #table-container with result -->
-    <form class="d-flex gap-2 align-items-stretch w-50" hx-get="{% url 'render_table' %}" hx-target="#table-container"
+    <form id="table-filters-form" class="d-flex gap-2 align-items-stretch w-50" hx-get="{% url 'render_table' %}" hx-target="#table-container"
         hx-trigger="change from:find select, keyup changed delay:300ms from:find input, clear from:find input">
         <select name="search_column" class="form-select form-select-md">
             <option value="">All columns</option>
@@ -50,19 +50,17 @@
         <button type="submit" class="btn btn-sm btn-primary">Assign Selected</button>
     </form>
     {% endif %}
-    <form method="get" action="{% url 'export_search_results' %}" class="mb-3" id="export-form">
-        {% csrf_token %}
-        <input type="hidden" name="search" value="{{ search }}">
-        <input type="hidden" name="search_column" value="{{ search_column }}">
-        <button type="button" class="btn btn-outline-success" id="export-button">
-            Export to Excel
-        </button>
-    </form>
-</div> 
 
-<div id="export-spinner" class="text-center my-3" style="display: none;">
-  <div class="spinner-border text-success" role="status"></div>
-  <div class="mt-2">Exporting...</div>
+    <div class="mb-3">
+        <button
+            type="button" 
+            class="btn btn-outline-success h-100" 
+            id="export-button"
+            hx-on:click="handleExportSearchResults(this, event)"
+            >Export to Excel
+                <span id="export-spinner"></span>
+        </button>
+    </div>
 </div>
 
 


### PR DESCRIPTION
### Acceptance criteria
- [ ] Spinner is applied when user clicks export button and request is issued, then removed when download of exported data completes

### Description
This PR modifies the export button so that it no longer triggers a form submit, but rather triggers a JavaScript function via HTMX on click. The JavaScript changes consolidate the existing functionality into a single asynchronous function, which handles the click event from the export button, applies styling, and issues a request against the export endpoint.

The JavaScript the takes the data returned from the Django view, encodes it in a URL via [creatObjectURL()](https://developer.mozilla.org/en-US/docs/Web/API/URL/createObjectURL_static), then applies the URL to a temporary anchor tag. The download action on the anchor tag is then triggered, and styling on the button is returned to normal.

The function also creates a `FormData` object from the existing table filters form, to alleviate the need for the functions that kept the hidden input fields in sync.

### Testing
I didn't add any automated tests, as there are no changes to Python. For manual testing, please ensure the download works with filters applied, and also with no filters applied, and that the button behaves as described.

![screencap](https://github.com/user-attachments/assets/636527e7-464b-4144-8e58-1f7c82b7ab46)
