### PR TITLE
SYS-1891: Improve export performance

### DIFF
--- a/charts/prod-ftvalabdata-values.yaml
+++ b/charts/prod-ftvalabdata-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/ftva-lab-data
-  tag: v1.0.1\2
+  tag: v1.0.2
   pullPolicy: Always
 
 nameOverride: ""

--- a/charts/prod-ftvalabdata-values.yaml
+++ b/charts/prod-ftvalabdata-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/ftva-lab-data
-  tag: v1.0.1
+  tag: v1.0.1\2
   pullPolicy: Always
 
 nameOverride: ""

--- a/ftva_lab_data/templates/release_notes.html
+++ b/ftva_lab_data/templates/release_notes.html
@@ -4,6 +4,20 @@
 <h3>Release Notes</h3>
 <hr/>
 
+<h4>1.0.2</h4>
+<p><i>July 3, 2025</i></p>
+<ul>
+    <li>Exports are now in CSV instead of XLSX.</li>
+    <li>Exports are significantly faster.</li>
+    <li>The spinner / download indicator is now active only during export.</li>
+</ul>
+
+<h4>1.0.1</h4>
+<p><i>July 1, 2025</i></p>
+<ul>
+    <li>Tweaked timeout for long exports.</li>
+</ul>
+
 <h4>1.0.0</h4>
 <p><i>July 1, 2025</i></p>
 <ul>

--- a/ftva_lab_data/templates/search_results.html
+++ b/ftva_lab_data/templates/search_results.html
@@ -50,15 +50,6 @@
         <button type="submit" class="btn btn-sm btn-primary">Assign Selected</button>
     </form>
     {% endif %}
-    <form method="get" action="{% url 'export_search_results' %}" class="mb-3" id="export-form">
-        {% csrf_token %}
-        <input type="hidden" name="search" value="{{ search }}">
-        <input type="hidden" name="search_column" value="{{ search_column }}">
-        <button type="button" class="btn btn-outline-success" id="export-button">
-            Export to CSV
-        </button>
-    </form>
-</div> 
 
     <div class="mb-3">
         <button
@@ -66,7 +57,7 @@
             class="btn btn-outline-success h-100" 
             id="export-button"
             hx-on:click="handleExportSearchResults(this, event)"
-            >Export to Excel
+            >Export to CSV
                 <span id="export-spinner"></span>
         </button>
     </div>

--- a/ftva_lab_data/tests.py
+++ b/ftva_lab_data/tests.py
@@ -730,9 +730,10 @@ class DataExportTestCase(TestCase):
         export_data = format_data_for_export(data_dicts)
 
         # Test that the assigned user's full name is formatted correctly
-        self.assertIn("Example User", export_data["assigned_user"].values)
+        # export_data is now a list of dicts, not a df
+        self.assertIn("Example User", export_data[0]["assigned_user"])
         # Check that the Statuses are concatenated correctly
         self.assertIn(
             "Duplicated in source data, Incorrect inv no in filename",
-            export_data["status"].values,
+            export_data[1]["status"],
         )

--- a/ftva_lab_data/views.py
+++ b/ftva_lab_data/views.py
@@ -312,7 +312,7 @@ def export_search_results(request: HttpRequest) -> StreamingHttpResponse:
     # Reset the buffer to the beginning so it can be read from the start
     csv_buffer.seek(0)
     response = StreamingHttpResponse(
-        csv_buffer,
+        csv_buffer,  # type: ignore
         content_type="text/csv",
         headers={
             "Content-Disposition": f"attachment; filename={filename}",

--- a/ftva_lab_data/views.py
+++ b/ftva_lab_data/views.py
@@ -288,8 +288,6 @@ def export_search_results(request: HttpRequest) -> StreamingHttpResponse:
     :param request: The HTTP request object.
     :return: a streaming HTTP response with the CSV file attachment.
     """
-    print("Starting export")
-    timestamp_debug = pd.Timestamp.now()
     search = request.GET.get("search", "")
     search_column = request.GET.get("search_column", "")
     search_fields = (
@@ -300,7 +298,6 @@ def export_search_results(request: HttpRequest) -> StreamingHttpResponse:
 
     # Include all fields in the DataFrame, even if they are not displayed
     data_dicts = [row.__dict__ for row in rows]
-    print(f"Time to get data: {pd.Timestamp.now() - timestamp_debug}")
     # Add, remove, and reorder fields as needed
     export_dicts = format_data_for_export(data_dicts)
 
@@ -308,7 +305,7 @@ def export_search_results(request: HttpRequest) -> StreamingHttpResponse:
     timestamp = pd.Timestamp.now().strftime("%Y%m%d_%H%M%S")
     filename = f"{filename_base}_{timestamp}.csv"
 
-    # format dicts into CSV so we can use a streaming response
+    # Format dicts into CSV so we can use a streaming response
     csv_buffer = io.StringIO()
     df = pd.DataFrame(export_dicts)
     df.to_csv(csv_buffer, index=False)

--- a/ftva_lab_data/views.py
+++ b/ftva_lab_data/views.py
@@ -288,6 +288,8 @@ def export_search_results(request: HttpRequest) -> HttpResponse:
     :param request: The HTTP request object.
     :return: An HTTP response with the Excel file attachment.
     """
+    print("Starting export")
+    timestamp_debug = pd.Timestamp.now()
     search = request.GET.get("search", "")
     search_column = request.GET.get("search_column", "")
     search_fields = (
@@ -298,8 +300,10 @@ def export_search_results(request: HttpRequest) -> HttpResponse:
 
     # Include all fields in the DataFrame, even if they are not displayed
     data_dicts = [row.__dict__ for row in rows]
+    print(f"Time to get data: {pd.Timestamp.now() - timestamp_debug}")
     # Add, remove, and reorder fields as needed
     export_df = format_data_for_export(data_dicts)
+    print(f"Time to format data: {pd.Timestamp.now() - timestamp_debug}")
 
     filename_base = "FTVA_DL_search_results"
     timestamp = pd.Timestamp.now().strftime("%Y%m%d_%H%M%S")
@@ -319,6 +323,8 @@ def export_search_results(request: HttpRequest) -> HttpResponse:
     buffer.seek(0)
     # Write the buffer content to the response
     response.write(buffer.read())
+    print("Returning response")
+    print(f"Total time: {pd.Timestamp.now() - timestamp_debug}")
 
     return response
 

--- a/ftva_lab_data/views_utils.py
+++ b/ftva_lab_data/views_utils.py
@@ -3,7 +3,6 @@ from django.db.models import Model, Q
 from django.db.models.query import QuerySet
 from .models import SheetImport
 from .forms import ItemForm
-import pandas as pd
 
 
 # Recursive implementation adapted from:
@@ -240,15 +239,15 @@ def get_items_per_page_options() -> list[int]:
     return [10, 20, 50, 100]
 
 
-def format_data_for_export(data_dicts: list[dict[str, Any]]) -> pd.DataFrame:
+def format_data_for_export(data_dicts: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Formats a list of dictionaries of SheetImport data for export to Excel.
 
     :param data_dicts: A list of dictionaries, each representing a row of data.
-    :return: A pandas DataFrame with the formatted data.
+    :return: A list of dicts with added status and assigned_user fields.
     """
 
     if not data_dicts:
-        return pd.DataFrame()
+        return []
 
     # Gather all IDs
     ids = [d["id"] for d in data_dicts]
@@ -276,5 +275,4 @@ def format_data_for_export(data_dicts: list[dict[str, Any]]) -> pd.DataFrame:
         # Remove the '_state' field added by Django
         data_dict.pop("_state", None)
 
-    df = pd.DataFrame(data_dicts)
-    return df
+    return data_dicts

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,3 @@ gunicorn==23.0.0
 whitenoise==6.9.0
 pandas==2.2.3
 openpyxl==3.1.5
-xlsxwriter==3.2.5


### PR DESCRIPTION
Implements [SYS-1891](https://uclalibrary.atlassian.net/browse/SYS-1891)

Makes two performance-focused changes to the Export functionality of the FTVA Digital Data app:

1. Refactors the helper function `format_data_for_export()` in `views_utils.py` to avoid calling `SheetImport.objects.get()` for every item in the output set. Instead, `prefetch_related` and `select_related` are used to only query the database once, and lookup dictionaries are used to minimize the logic that happens inside the main loop.

This change is responsible for most of the performance improvement I saw locally, bringing the time to export all records from 42 seconds to 22 seconds.

2. Returns a CSV file via a `StreamingHttpResponse` instead of a binary Excel file with a standard `HttpResponse`. 

This change bought me an additional 5 seconds, taking the time to export all records down to 17 seconds.

`pandas` is still used internally to create the CSV file. I did not see any performance improvement if this is done with the `csv` package instead, and `pandas` allows for simpler code than would be needed with `csv.Dictwriter()`.

Additionally includes:

* Update to search results template to change button wording to "Export to CSV"
* Update to `requirements.txt` to remove `xlsxwriter` package
* Update to tests to work with new dict structure returned by `format_data_for_export()`
* Tag bump for deployment



[SYS-1891]: https://uclalibrary.atlassian.net/browse/SYS-1891?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ