### PR TITLE
SYS-1901: Add search fields for `SheetImportAdmin` class

### DIFF
--- a/ftva_lab_data/admin.py
+++ b/ftva_lab_data/admin.py
@@ -11,4 +11,4 @@ class ItemStatusAdmin(admin.ModelAdmin):
 
 @admin.register(SheetImport)
 class SheetImportAdmin(SimpleHistoryAdmin):
-    search_fields = ("id",)
+    search_fields = ("id__exact",)


### PR DESCRIPTION
Implements [SYS-1901](https://uclalibrary.atlassian.net/browse/SYS-1901)

### Acceptance criteria
- [x] When authorized users click on [Sheet imports in the Admin interface](http://127.0.0.1:8000/admin/ftva_lab_data/sheetimport/), they have the option to enter a specific record id to go quickly to that specific record.  This is needed so they can view the History for that record.

### Description
I added a new class to `ftva_lab_data/admin.py`, which extends the `SimpleHistoryAdmin` class in use on the admin site for `SheetImport`. I also changed the `admin.site.register` lines to `@admin.register`, for consistency with how it was done in our [TERRA](https://github.com/UCLALibrary/terra/blob/main/terra/admin.py#L67) application.

I don't think the `ItemStatusAdmin` class was doing anything prior to this change, as the class was declared but not registered on the admin site for the `ItemStatus` model. I went ahead and registered it, so item statuses are now also searchable on the admin site, though that's probably not necessary.

### Testing
No automated tests, as a unit test would just be demonstrating that Django works, I think. Please manually confirm that the sheet import records are searchable by ID on the admin site linked above.

[SYS-1901]: https://uclalibrary.atlassian.net/browse/SYS-1901?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ