### PR TITLE
SYS-1904: Increase memory allocation

### DIFF
--- a/charts/prod-ftvalabdata-values.yaml
+++ b/charts/prod-ftvalabdata-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/ftva-lab-data
-  tag: v1.0.3
+  tag: v1.0.4
   pullPolicy: Always
 
 nameOverride: ""
@@ -59,13 +59,15 @@ django:
       db_password: "/systems/prodrke01/ftva-lab-data/db_password"
       django_secret_key: "/systems/prodrke01/ftva-lab-data/django_secret_key"
 
+# Memory request and limit both set to 1Gi to deal with out of memory
+# errors when running full CSV export.
 resources:
   limits:
     cpu: 500m
-    memory: 500Mi
+    memory: 1Gi
   requests:
     cpu: 250m
-    memory: 100Mi
+    memory: 1Gi
 
 nodeSelector: {}
 

--- a/ftva_lab_data/templates/release_notes.html
+++ b/ftva_lab_data/templates/release_notes.html
@@ -4,6 +4,12 @@
 <h3>Release Notes</h3>
 <hr/>
 
+<h4>1.0.4</h4>
+<p><i>July 15, 2025</i></p>
+<ul>
+    <li>Increased memory allocation via Helm chart.</li>
+</ul>
+
 <h4>1.0.3</h4>
 <p><i>July 14, 2025</i></p>
 <ul>


### PR DESCRIPTION
Fixes (hopefully) [SYS-1904](https://uclalibrary.atlassian.net/browse/SYS-1904).  Tagger as version `v1.0.4` for deployment.

This PR increases the memory limits for the Django pod when deployed to our Kubernetes environment.  Per advice from the infrastructure team, both the request (the minimum allocated) and the limit for memory have been set to 1Gi.  We won't know if this allows the full CSV export to run successfully until deployed.


[SYS-1904]: https://uclalibrary.atlassian.net/browse/SYS-1904?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ