### PR TITLE
SYS-1912: Add 5 new item status values

### DIFF
--- a/ftva_lab_data/fixtures/item_statuses.json
+++ b/ftva_lab_data/fixtures/item_statuses.json
@@ -54,5 +54,40 @@
     "fields": {
       "status": "Needs review"
     }
+  },
+  {
+    "model": "ftva_lab_data.itemstatus",
+    "pk": 9,
+    "fields": {
+      "status": "Curator reviewed - Do not ingest"
+    }
+  },
+  {
+    "model": "ftva_lab_data.itemstatus",
+    "pk": 10,
+    "fields": {
+      "status": "Curator reviewed - Ingest"
+    }
+  },
+  {
+    "model": "ftva_lab_data.itemstatus",
+    "pk": 11,
+    "fields": {
+      "status": "DL Reviewed - Do not ingest"
+    }
+  },
+  {
+    "model": "ftva_lab_data.itemstatus",
+    "pk": 12,
+    "fields": {
+      "status": "DL Reviewed - Ingest"
+    }
+  },
+  {
+    "model": "ftva_lab_data.itemstatus",
+    "pk": 13,
+    "fields": {
+      "status": "Ingested"
+    }
   }
 ]


### PR DESCRIPTION
Implements [SYS-1912](https://uclalibrary.atlassian.net/browse/SYS-1912). Not tagged for deployment, this is a data-only change.

This PR adds 5 new item status values to the `item_statuses.json` fixture
* Curator reviewed - Do not ingest
* Curator reviewed - Ingest
* DL Reviewed - Do not ingest
* DL Reviewed - Ingest
* Ingested

No new tests needed; existing tests all still pass.  Verified locally that the new statuses display and work same as the existing ones.
