### PR TITLE
SYS-1929: Encode search to make safe for URL query strings

### DIFF
--- a/charts/prod-ftvalabdata-values.yaml
+++ b/charts/prod-ftvalabdata-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/ftva-lab-data
-  tag: v1.0.4
+  tag: v1.0.5
   pullPolicy: Always
 
 nameOverride: ""

--- a/ftva_lab_data/templates/add_edit_item.html
+++ b/ftva_lab_data/templates/add_edit_item.html
@@ -22,7 +22,7 @@
         </div>
 
         <a class="btn btn-outline-danger"
-            href="{% if item %}{% url 'view_item' item.id %}{% else %}{% url 'search_results' %}{% endif %}?search={{ search }}&search_column={{ search_column }}&page={{ page }}">
+            href="{% if item %}{% url 'view_item' item.id %}{% else %}{% url 'search_results' %}{% endif %}?{{ url_encoded_search }}&search_column={{ search_column }}&page={{ page }}">
             Cancel</a>
     </div>
 

--- a/ftva_lab_data/templates/add_edit_item.html
+++ b/ftva_lab_data/templates/add_edit_item.html
@@ -22,7 +22,7 @@
         </div>
 
         <a class="btn btn-outline-danger"
-            href="{% if item %}{% url 'view_item' item.id %}{% else %}{% url 'search_results' %}{% endif %}?{{ url_encoded_search }}&search_column={{ search_column }}&page={{ page }}">
+            href="{% if item %}{% url 'view_item' item.id %}{% else %}{% url 'search_results' %}{% endif %}?{{ url_parameters }}">
             Cancel</a>
     </div>
 

--- a/ftva_lab_data/templates/partials/pagination_controls.html
+++ b/ftva_lab_data/templates/partials/pagination_controls.html
@@ -10,7 +10,8 @@
                 name="items_per_page"
                 class="form-select form-select-md"
                 style="width: fit-content;"
-                hx-get="{% url 'render_table' %}?{{ url_encoded_search }}&search_column={{ search_column }}"
+                hx-get="{% url 'render_table' %}"
+                hx-include="#table-filters-form"
                 hx-target="#table-container"    
             >
                 {% for option in items_per_page_options %}
@@ -25,7 +26,8 @@
     <div class="col d-flex justify-content-center align-items-center gap-2">
         <button class="btn btn-primary"
             {% if page_obj.has_previous %}
-                hx-get="{% url 'render_table' %}?page={{ page_obj.previous_page_number }}&{{ url_encoded_search }}&search_column={{ search_column }}"
+                hx-get="{% url 'render_table' %}?page={{ page_obj.previous_page_number }}"
+                hx-include="#table-filters-form"
                 hx-target="#table-container"
             {% else %} disabled {% endif %}>
             Previous
@@ -37,7 +39,8 @@
                 <span class="btn btn-secondary active mx-1">{{ page }}</span>
             {% else %}
                 <button class="btn btn-outline-secondary mx-1"
-                    hx-get="{% url 'render_table' %}?page={{ page }}&{{ url_encoded_search }}&search_column={{ search_column }}"
+                    hx-get="{% url 'render_table' %}?page={{ page }}"
+                    hx-include="#table-filters-form"
                     hx-target="#table-container">
                     {{ page }}
                 </button>
@@ -45,7 +48,8 @@
         {% endfor %}
         <button class="btn btn-primary"
             {% if page_obj.has_next %}
-                hx-get="{% url 'render_table' %}?page={{ page_obj.next_page_number }}&{{ url_encoded_search }}&search_column={{ search_column }}"
+                hx-get="{% url 'render_table' %}?page={{ page_obj.next_page_number }}"
+                hx-include="#table-filters-form"
                 hx-target="#table-container"
             {% else %} disabled {% endif %}>
             Next

--- a/ftva_lab_data/templates/partials/pagination_controls.html
+++ b/ftva_lab_data/templates/partials/pagination_controls.html
@@ -10,7 +10,7 @@
                 name="items_per_page"
                 class="form-select form-select-md"
                 style="width: fit-content;"
-                hx-get="{% url 'render_table' %}?search={{ search }}&search_column={{ search_column }}"
+                hx-get="{% url 'render_table' %}?{{ url_encoded_search }}&search_column={{ search_column }}"
                 hx-target="#table-container"    
             >
                 {% for option in items_per_page_options %}
@@ -25,7 +25,7 @@
     <div class="col d-flex justify-content-center align-items-center gap-2">
         <button class="btn btn-primary"
             {% if page_obj.has_previous %}
-                hx-get="{% url 'render_table' %}?page={{ page_obj.previous_page_number }}&search={{ search }}&search_column={{ search_column }}"
+                hx-get="{% url 'render_table' %}?page={{ page_obj.previous_page_number }}&{{ url_encoded_search }}&search_column={{ search_column }}"
                 hx-target="#table-container"
             {% else %} disabled {% endif %}>
             Previous
@@ -37,7 +37,7 @@
                 <span class="btn btn-secondary active mx-1">{{ page }}</span>
             {% else %}
                 <button class="btn btn-outline-secondary mx-1"
-                    hx-get="{% url 'render_table' %}?page={{ page }}&search={{ search }}&search_column={{ search_column }}"
+                    hx-get="{% url 'render_table' %}?page={{ page }}&{{ url_encoded_search }}&search_column={{ search_column }}"
                     hx-target="#table-container">
                     {{ page }}
                 </button>
@@ -45,7 +45,7 @@
         {% endfor %}
         <button class="btn btn-primary"
             {% if page_obj.has_next %}
-                hx-get="{% url 'render_table' %}?page={{ page_obj.next_page_number }}&search={{ search }}&search_column={{ search_column }}"
+                hx-get="{% url 'render_table' %}?page={{ page_obj.next_page_number }}&{{ url_encoded_search }}&search_column={{ search_column }}"
                 hx-target="#table-container"
             {% else %} disabled {% endif %}>
             Next

--- a/ftva_lab_data/templates/partials/search_results_table.html
+++ b/ftva_lab_data/templates/partials/search_results_table.html
@@ -59,7 +59,7 @@ See comment on partial as well.
                         <div class="d-flex flex-column align-items-start">
                             <!--View link includes search parameters, for later use by "Back to Search" button-->
                             <a class="btn btn-link btn-sm p-0" 
-                            href="{% url 'view_item' row.id %}?search={{ search }}&search_column={{ search_column }}&page={{ page_obj.number }}">
+                            href="{% url 'view_item' row.id %}?{{ url_encoded_search }}&search_column={{ search_column }}&page={{ page_obj.number }}">
                             View</a> 
                             <br>
                             <span class="text-muted small">ID: {{ value }}</span>

--- a/ftva_lab_data/templates/partials/search_results_table.html
+++ b/ftva_lab_data/templates/partials/search_results_table.html
@@ -59,7 +59,7 @@ See comment on partial as well.
                         <div class="d-flex flex-column align-items-start">
                             <!--View link includes search parameters, for later use by "Back to Search" button-->
                             <a class="btn btn-link btn-sm p-0" 
-                            href="{% url 'view_item' row.id %}?{{ url_encoded_search }}&search_column={{ search_column }}&page={{ page_obj.number }}">
+                            href="{% url 'view_item' row.id %}?{{ url_parameters }}">
                             View</a> 
                             <br>
                             <span class="text-muted small">ID: {{ value }}</span>

--- a/ftva_lab_data/templates/release_notes.html
+++ b/ftva_lab_data/templates/release_notes.html
@@ -4,6 +4,12 @@
 <h3>Release Notes</h3>
 <hr/>
 
+<h4>1.0.5</h4>
+<p><i>July 25, 2025</i></p>
+<ul>
+    <li>Fix bug related to reserved characters in URL query strings.</li>
+</ul>
+
 <h4>1.0.4</h4>
 <p><i>July 15, 2025</i></p>
 <ul>

--- a/ftva_lab_data/templates/search_results.html
+++ b/ftva_lab_data/templates/search_results.html
@@ -67,7 +67,8 @@
 <!-- On page load, HTMX triggers GET request to 'render_table'
 and inserts it within div -->
 <div id="table-container" class="table-responsive container-fluid p-4"
-     hx-get="{% url 'render_table' %}?{{ url_encoded_search }}&search_column={{ search_column }}&page={{ page }}"
+     hx-get="{% url 'render_table' %}"
+     hx-include="#table-filters-form"
      hx-trigger="load">
 </div>
 

--- a/ftva_lab_data/templates/search_results.html
+++ b/ftva_lab_data/templates/search_results.html
@@ -11,9 +11,9 @@
 
 <div class="d-flex align-items-stretch gap-2 mb-3 w-75 mx-auto">
 
-    <!-- HTMX will listen for triggers from enclosed controls,
+    {% comment %} HTMX will listen for triggers from enclosed controls,
     then issue GET requests to 'render_table' URL
-    and replace content of #table-container with result -->
+    and replace content of #table-container with result {% endcomment %}
     <form id="table-filters-form" class="d-flex gap-2 align-items-stretch w-50" hx-get="{% url 'render_table' %}" hx-target="#table-container"
         hx-trigger="change from:find select, keyup changed delay:300ms from:find input, clear from:find input">
         <select name="search_column" class="form-select form-select-md">
@@ -64,10 +64,12 @@
 </div>
 
 
-<!-- On page load, HTMX triggers GET request to 'render_table'
-and inserts it within div -->
+{% comment %} On page load, HTMX triggers GET request to 'render_table'
+and inserts the resulting HTML within div. HTMX includes the child fields of
+`table-filters-form` from above, but since the state of `page` is managed
+elsewhere, it is included in the URL query string here. {% endcomment %}
 <div id="table-container" class="table-responsive container-fluid p-4"
-     hx-get="{% url 'render_table' %}"
+     hx-get="{% url 'render_table' %}?page={{ page }}"
      hx-include="#table-filters-form"
      hx-trigger="load">
 </div>

--- a/ftva_lab_data/templates/search_results.html
+++ b/ftva_lab_data/templates/search_results.html
@@ -67,7 +67,7 @@
 <!-- On page load, HTMX triggers GET request to 'render_table'
 and inserts it within div -->
 <div id="table-container" class="table-responsive container-fluid p-4"
-     hx-get="{% url 'render_table' %}?search={{ search }}&search_column={{ search_column }}&page={{ page }}"
+     hx-get="{% url 'render_table' %}?{{ url_encoded_search }}&search_column={{ search_column }}&page={{ page }}"
      hx-trigger="load">
 </div>
 

--- a/ftva_lab_data/templates/view_item.html
+++ b/ftva_lab_data/templates/view_item.html
@@ -27,14 +27,14 @@
                 hx-on:click="toggleAdvancedFields(this)">Show Advanced Fields</button>
             {% if perms.ftva_lab_data.change_sheetimport %}
             <a class="btn btn-primary"
-            href="{% url 'edit_item' header_info.id %}?search={{ search }}&search_column={{ search_column }}&page={{ page }}">
+            href="{% url 'edit_item' header_info.id %}?{{ url_encoded_search }}&search_column={{ search_column }}&page={{ page }}">
             Edit This Record
             </a>
             {% endif %}
         </div>
 
         <a class="btn btn-outline-secondary"
-        href="{% url 'search_results' %}?search={{ search }}&search_column={{ search_column }}&page={{ page }}">
+        href="{% url 'search_results' %}?{{ url_encoded_search }}&search_column={{ search_column }}&page={{ page }}">
         Back to Search
         </a>
     </div>

--- a/ftva_lab_data/templates/view_item.html
+++ b/ftva_lab_data/templates/view_item.html
@@ -27,14 +27,14 @@
                 hx-on:click="toggleAdvancedFields(this)">Show Advanced Fields</button>
             {% if perms.ftva_lab_data.change_sheetimport %}
             <a class="btn btn-primary"
-            href="{% url 'edit_item' header_info.id %}?{{ url_encoded_search }}&search_column={{ search_column }}&page={{ page }}">
+            href="{% url 'edit_item' header_info.id %}?{{ url_parameters }}">
             Edit This Record
             </a>
             {% endif %}
         </div>
 
         <a class="btn btn-outline-secondary"
-        href="{% url 'search_results' %}?{{ url_encoded_search }}&search_column={{ search_column }}&page={{ page }}">
+        href="{% url 'search_results' %}?{{ url_parameters }}">
         Back to Search
         </a>
     </div>

--- a/ftva_lab_data/views.py
+++ b/ftva_lab_data/views.py
@@ -7,7 +7,6 @@ from django.http import HttpRequest, HttpResponse, StreamingHttpResponse
 from django.shortcuts import render, redirect
 from django.template.loader import render_to_string
 from django.urls import reverse
-from urllib.parse import urlencode
 import pandas as pd
 import io
 
@@ -107,7 +106,7 @@ def edit_item(request: HttpRequest, item_id: int) -> HttpResponse:
             messages.success(request, "Item updated successfully!")
             url = (
                 f"{reverse('view_item', args=[item.id])}"
-                f"?{urlencode({"search": search})}&search_column={search_column}&page={page}"
+                f"?{build_url_parameters(search=search, search_column=search_column, page=page)}"
             )
             return redirect(url)
 

--- a/ftva_lab_data/views.py
+++ b/ftva_lab_data/views.py
@@ -163,13 +163,16 @@ def search_results(request: HttpRequest) -> HttpResponse:
     # Retrieve search params
     search = request.GET.get("search", "")
     search_column = request.GET.get("search_column", "")
-    # page = request.GET.get("page", "")
+    page = request.GET.get("page", "")
 
+    # The search parameters, while encoded as a query string elsewhere,
+    # need to be returned individually here to sync with input element values.
     search_results_context = {
         "columns": COLUMNS,
         "users": users,
         "search": search,
         "search_column": search_column,
+        "page": page,
     }
 
     # Pass search params from GET to template context,

--- a/ftva_lab_data/views_utils.py
+++ b/ftva_lab_data/views_utils.py
@@ -1,6 +1,7 @@
 from typing import Any
 from django.db.models import Model, Q
 from django.db.models.query import QuerySet
+from urllib.parse import urlencode
 from .models import SheetImport
 from .forms import ItemForm
 
@@ -278,3 +279,12 @@ def format_data_for_export(data_dicts: list[dict[str, Any]]) -> list[dict[str, A
         data_dict.pop("_state", None)
 
     return data_dicts
+
+
+def build_url_parameters(**kwargs) -> str:
+    """Encodes URL parameters as a string ready for use as a query string in the templates.
+
+    :param **kwargs: Keyword arguments representing URL parameters.
+    :return: An encoded URL query string.
+    """
+    return urlencode(kwargs)


### PR DESCRIPTION
Fixes [SYS-1929](https://uclalibrary.atlassian.net/browse/SYS-1929)

### Acceptance criteria
- [x] Reserved characters in search strings are properly encoded in URL query strings
- [x] When navigating from item view or other pages to the home table view, search is preserved, so that the correct number of results display

### Description
This PR updates `views.py` to return an encoded version of the string entered in the search input, safe for use in URL query strings. This `url_encoded_search` is then passed to the relevant templates in the view contexts, and from there passed between pages in the URL query strings to address the bug caused by reserved characters (e.g. `&`, `+`, `#`, etc) in the search param.

### Testing
No new automated tests. All 44 existing tests pass. Please manually confirm all the example searches described in the Jira issue yield the expected number of results, particularly when navigating from the item view to the table view via the "Back to Search" button.

### Discussion
**TL;DR**
HTMX offers a lot of convenience via attributes like [hx-include](https://htmx.org/attributes/hx-include/), but adopting it more fully would push the application toward a single-page application (SPA) style. That would likely require a fair amount of refactoring, and it ain't broken, so perhaps it's wise to not fix it.

--

Addressing this bug made me realize that there are likely ways to more fully utilize HTMX. Currently, we employ a hybrid approach between idiomatic Django and HTMX. Consider the following code snippet:

```
<div id="table-container" class="table-responsive container-fluid p-4"
     hx-get="{% url 'render_table' %}?{{ url_encoded_search }}&search_column={{ search_column }}&page={{ page }}"
     hx-trigger="load">
</div>
```

Here we use the `hx-get` attribute to make a request to the `render_table` view, and we pass parameters in the URL query string (which was just updated in this PR to encode the `search` parameter). For the `search` and `search_column` params, we could use [hx-include](https://htmx.org/attributes/hx-include/), which gets values from child `input` and `select` elements of the target DOM element, then automatically includes them as encoded params in the prepared AJAX request.

In `partials/search_results_table.html`, we include an anchor tag for each row in the table, which navigates to the item view for the associated record:

```
<a class="btn btn-link btn-sm p-0"
href="{% url 'view_item' row.id %}?{{ url_encoded_search }}&search_column={{ search_column }}&page={{ page_obj.number }}">View</a> 
```

If this element were to use `hx-get` rather than `href`, we could utilize HTMX to swap in the resulting item view, rather than initiating a full page reload. A similar pattern could be followed for other navigation that results in a full page reload. This would make the front-end of the application more of a single-page application (SPA).

Here are some pros and cons for utilizing HTMX more fully, as I see them:
**Pros**
HTMX provides a lot of convenience for doing things like encoding URL params. As it relates to the bug at hand, HTMX could allow us to avoid long query strings in links by using the `hx-include` attribute to refer to the `#table-filters-form` element as the source for the search parameters.

**Cons**
The more we adopt HTMX, the more "locked in" to it we get. It would push the application more toward a SPA style, which could introduce more awkwardness in working with Django's built-in features.





[SYS-1929]: https://uclalibrary.atlassian.net/browse/SYS-1929?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ