### PR TITLE
SYS-1938: management command to set status for items with no locations

### DIFF
--- a/ftva_lab_data/management/commands/set_empty_location_status.py
+++ b/ftva_lab_data/management/commands/set_empty_location_status.py
@@ -1,0 +1,38 @@
+import logging
+from django.core.management.base import BaseCommand
+from ftva_lab_data.models import SheetImport, ItemStatus
+
+logger = logging.getLogger(__name__)
+
+
+def set_empty_location_status() -> None:
+    """Set the status of records with empty locations."""
+    # Get all records where all of the location fields are empty:
+    # hard_drive_location, carrier_a_location, and carrier_b_location.
+    records = SheetImport.objects.filter(
+        hard_drive_location="",
+        carrier_a_location="",
+        carrier_b_location="",
+    )
+    logger.info(f"Found {records.count()} records with empty locations.")
+
+    # Filter out records that already have the 'Invalid vault' status
+    records_to_update = records.exclude(status__status="Invalid vault")
+    logger.info(
+        f"Filtered down to {records_to_update.count()} records without 'Invalid vault' status."
+    )
+    invalid_vault_status = ItemStatus.objects.get(status="Invalid vault")
+    for record in records_to_update:
+        # Django's .add() method will save the change to the database automatically
+        record.status.add(invalid_vault_status)
+    logger.info(f"Added 'Invalid vault' status to {records_to_update.count()} records.")
+
+
+class Command(BaseCommand):
+    help = (
+        "Set a status of 'Invalid vault' for all SheetImport records with an empty"
+        " hard_drive_location, or an empty carrier_a_location AND an empty carrier_b_location."
+    )
+
+    def handle(self, *args, **options) -> None:
+        set_empty_location_status()

--- a/ftva_lab_data/tests.py
+++ b/ftva_lab_data/tests.py
@@ -6,6 +6,9 @@ from ftva_lab_data.forms import ItemForm
 from ftva_lab_data.management.commands.set_empty_inv_no_status import (
     set_empty_inv_no_status,
 )
+from ftva_lab_data.management.commands.set_empty_location_status import (
+    set_empty_location_status,
+)
 from ftva_lab_data.management.commands.clean_tape_info import (
     get_tape_info_parts,
     process_carrier_fields,
@@ -795,3 +798,41 @@ class SetEmptyInvNoStatusTestCase(TestCase):
 
         # Check that no status was added
         self.assertFalse(item.status.filter(status="Invalid inv no").exists())
+
+
+class SetEmptyLocationStatusTestCase(TestCase):
+    """Tests the set_empty_location_status management command."""
+
+    fixtures = ["item_statuses.json"]
+
+    def test_set_empty_location_status(self):
+        # Create a SheetImport object with no locations set
+        item = SheetImport.objects.create(file_name="test_file")
+        set_empty_location_status()
+
+        # Check that the status was set correctly
+        self.assertTrue(item.status.filter(status="Invalid vault").exists())
+
+    def test_set_empty_location_status_no_updates(self):
+        # Create a SheetImport object a valid carrier_a location
+        item = SheetImport.objects.create(
+            file_name="test_file",
+            carrier_a_location="a_location",
+        )
+        set_empty_location_status()
+
+        # Check that no status was added
+        self.assertFalse(item.status.filter(status="Invalid vault").exists())
+
+    def test_set_empty_location_status_existing_status(self):
+        # Create a SheetImport object with no locations set
+        # and an existing 'Needs review' status
+        item = SheetImport.objects.create(file_name="test_file")
+        item.status.add(ItemStatus.objects.get(status="Needs review"))
+
+        set_empty_location_status()
+
+        # Check that both statuses are present, and exactly two statuses exist
+        self.assertTrue(item.status.filter(status="Invalid vault").exists())
+        self.assertTrue(item.status.filter(status="Needs review").exists())
+        self.assertEqual(item.status.count(), 2)

--- a/ftva_lab_data/tests.py
+++ b/ftva_lab_data/tests.py
@@ -814,7 +814,7 @@ class SetEmptyLocationStatusTestCase(TestCase):
         self.assertTrue(item.status.filter(status="Invalid vault").exists())
 
     def test_set_empty_location_status_no_updates(self):
-        # Create a SheetImport object a valid carrier_a location
+        # Create a SheetImport object with a valid carrier_a location
         item = SheetImport.objects.create(
             file_name="test_file",
             carrier_a_location="a_location",


### PR DESCRIPTION
Implements [SYS-1938](https://uclalibrary.atlassian.net/browse/SYS-1938)

Adds a new management command, `set_empty_location_status`. This command finds all `SheetImport` objects where `hard_drive_location`, `carrier_a_location`, and `carrier_b_location` are all empty, and sets a status of "Invalid vault" on these items.

The logic implemented here (and described in the Jira ticket) has changed since last week - I confirmed with Thelma this morning that we want to use the original statement of the logic (For any record where Carrier A location AND Carrier B location AND Hard Drive location are null, mark Status as invalid vault), not the version from Thursday (For any record where both Carrier A location AND Carrier B location are null, OR Hard Drive location is null, mark Status as "invalid vault.").

Run as other management commands: `python manage.py set_empty_location_status`. Messages with counts of updated records will be available in the logs.

Three new tests added, for a total of 50: `python manage.py test`

[SYS-1938]: https://uclalibrary.atlassian.net/browse/SYS-1938?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ