### PR TITLE
SYS-1942: add record retrieval endpoint w/HTTP basic auth

### DIFF
--- a/ftva_lab_data/tests.py
+++ b/ftva_lab_data/tests.py
@@ -202,9 +202,7 @@ class UserAccessTestCase(TestCase):
         """Asserts that a user with basic auth can GET a record."""
         # Construct HTTP Basic Auth credentials
         credentials = "authorized:testpassword"
-        base64_credentials = base64.b64encode(credentials.encode("utf-8")).decode(
-            "utf-8"
-        )
+        base64_credentials = base64.b64encode(credentials.encode()).decode()
         url = reverse("get_record", args=[self.test_object.id])
         response = self.client.get(
             url, HTTP_AUTHORIZATION=f"Basic {base64_credentials}"
@@ -217,9 +215,7 @@ class UserAccessTestCase(TestCase):
         """Asserts that a user with bad basic auth credentials receives 401."""
         # Construct HTTP Basic Auth credentials with incorrect password
         credentials = "authorized:wrongpassword"
-        base64_credentials = base64.b64encode(credentials.encode("utf-8")).decode(
-            "utf-8"
-        )
+        base64_credentials = base64.b64encode(credentials.encode()).decode()
         url = reverse("get_record", args=[self.test_object.id])
         response = self.client.get(
             url, HTTP_AUTHORIZATION=f"Basic {base64_credentials}"

--- a/ftva_lab_data/urls.py
+++ b/ftva_lab_data/urls.py
@@ -16,4 +16,5 @@ urlpatterns = [
     path("logs/", views.show_log, name="show_log"),
     path("logs/<int:line_count>", views.show_log, name="show_log"),
     path("release_notes/", views.release_notes, name="release_notes"),
+    path("records/<int:record_id>/", views.get_record, name="get_record"),
 ]

--- a/ftva_lab_data/views.py
+++ b/ftva_lab_data/views.py
@@ -369,7 +369,7 @@ def release_notes(request: HttpRequest) -> HttpResponse:
 
 
 @basic_auth_required
-def get_record(request: HttpRequest, record_id: int) -> HttpResponse:
+def get_record(request: HttpRequest, record_id: int) -> JsonResponse:
     """Retrieve a specific record by ID as JSON, intended for API use.
 
     :param request: The HTTP request object.


### PR DESCRIPTION
Implements [SYS-1942](https://uclalibrary.atlassian.net/browse/SYS-1942)

Adds a new endpoint, `/records/<record_id:int>`, that retrieves JSON data for an individual `SheetImport` object.

The endpoint uses HTTP basic auth, and requires valid Django account credentials (username and password for an active user). To support this, I added a new `basic_auth_required` decorator, defined in `views_utils.py`.

Given that this data will be used outside of this application, I wasn't sure whether to include Status and Assigned User data in the output JSON. I opted to include both for now.

Two simple success/failure tests are added in `tests.py`, for a total of 53: `python manage.py test`

[SYS-1942]: https://uclalibrary.atlassian.net/browse/SYS-1942?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ