### PR TITLE
SYS-1924: Add git and support for local env secrets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ USER django
 COPY --chown=django:django . .
 
 # Include local python bin into django user's path, mostly for pip
-ENV PATH /home/django/.local/bin:${PATH}
+ENV PATH=/home/django/.local/bin:${PATH}
 
 # Make sure pip is up to date, and don't complain if it isn't yet
 RUN pip install --upgrade pip --disable-pip-version-check

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,9 @@ RUN apt-get update
 # Set correct timezone
 RUN ln -sf /usr/share/zoneinfo/America/Los_Angeles /etc/localtime
 
-# Install dependencies needed to build psycopg python module
-RUN apt-get install -y gcc python3-dev libpq-dev
+# Install dependencies needed to build psycopg python module.
+# Also install git, needed for pip to install our local packages from github.
+RUN apt-get install -y gcc python3-dev libpq-dev git
 
 # Create django user
 RUN useradd -c "django app user" -d /home/django -s /bin/bash -m django

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,10 +5,13 @@ services:
     volumes:
       - .:/home/django/ftva-lab-data
     env_file:
-      - .docker-compose_django.env
-      - .docker-compose_db.env
-      # Local development only
-      # - .docker-compose_secrets.env
+      - path: .docker-compose_django.env
+        required: true
+      - path: .docker-compose_db.env
+        required: true
+      # Local development only, can be optional
+      - path: .docker-compose_local_secrets.env
+        required: false
     ports:
       # Variables here must be set in environment, or in .env - not in any env_file
       - "8000:8000"

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ gunicorn==23.0.0
 whitenoise==6.9.0
 pandas==2.2.3
 openpyxl==3.1.5
+# Local package for Alma & Filemaker integration.
+git+https://github.com/UCLALibrary/ftva-etl.git


### PR DESCRIPTION
Implements [SYS-1924](https://uclalibrary.atlassian.net/browse/SYS-1924).  Local-only, no deployment needed.

This PR makes three small changes to the developer environment:
* Add `git` to the `django` container, so local packages can be installed by `pip` from Github.
* Add support for local secrets, for the development environment only.
* Add our new local `ftva_etl` package to `requirements.txt`.

`docker-compose.yml` now will load an optional local file, `.docker-compose_local_secrets.env`.  This can contain any local values which need to be available to the running `django` container, like API keys and other real values which need to be kept secret.  These will be handled securely in our production deployment environment, but cannot be in the GH repository.

This secrets file does not need to exist.  Developers can share with each other as needed, or use their own personal credentials as appropriate.

Since env files are loaded in order, local / personal values can also be used to override placeholder defaults.

To test: shut down the application if running, and rebuild to pick up the `Dockerfile` changes:
```
docker compose down
docker compose build
docker compose up -d
```
@henry-r18 @ztucker4 FYI, just one review is plenty - whoever tests and confirms first, please merge.


[SYS-1924]: https://uclalibrary.atlassian.net/browse/SYS-1924?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ