### PR TITLE
Sys 1944/get alma data

### DIFF
--- a/ftva_lab_data/views.py
+++ b/ftva_lab_data/views.py
@@ -415,8 +415,13 @@ def get_alma_data(request: HttpRequest, inventory_number: str) -> list[dict]:
     for record in records:
         record_dict = {}
         # Extract the record ID and title, used for search results display
-        record_dict["record_id"] = record.get_fields("001")[0].value()
-        record_dict["title"] = record.title
+        record_dict["record_id"] = record.get("001").value()
+        # Get relevant subfields from the 245 field for the title
+        title_subfields = ["a", "b", "p", "n"]
+        title_components = record.get("245").get_subfields(*title_subfields)
+        record_dict["title"] = " ".join(
+            [subfield for subfield in title_components if subfield]
+        )
 
         # Process the full MARC data to get relevant fields processed into a dict
         record_fields = sru_client.get_fields(record, marc_fields)

--- a/ftva_lab_data/views.py
+++ b/ftva_lab_data/views.py
@@ -397,12 +397,13 @@ def get_record(request: HttpRequest, record_id: int) -> JsonResponse:
         return JsonResponse({"error": "Record not found"}, status=404)
 
 
-@login_required
-def get_alma_data(request: HttpRequest, inventory_number: str) -> HttpResponse:
+def get_alma_data(request: HttpRequest, inventory_number: str) -> list[dict]:
     """Fetch Alma records using SRU client.
 
     :param request: The HTTP request object.
-    :return: Rendered HTML for the Alma records.
+    :param inventory_number: The inventory number to search for in Alma.
+    :return: a list of dictionaries containing Alma record data, each with keys
+        "record_id", "title", and "full_data".
     """
     sru_client = AlmaSRUClient()
     records = sru_client.search_by_call_number(inventory_number)
@@ -424,10 +425,5 @@ def get_alma_data(request: HttpRequest, inventory_number: str) -> HttpResponse:
         full_data_dicts.append(record_dict)
 
     # TODO: return a template with the records
-    # For now, just return a simple text response
-    response_content = f"Found {len(records)} records for {inventory_number}:\n"
-    for record in full_data_dicts:
-        response_content += f"Record ID: {record['record_id']}\n"
-        response_content += f"Title: {record['title']}\n"
-        response_content += f"Full Data: {record['full_data']}\n\n"
-    return HttpResponse(response_content, content_type="text/plain")
+    # For now, just return the list of dictionaries
+    return full_data_dicts

--- a/ftva_lab_data/views.py
+++ b/ftva_lab_data/views.py
@@ -417,7 +417,7 @@ def get_alma_data(request: HttpRequest, inventory_number: str) -> list[dict]:
         # Extract the record ID and title, used for search results display
         record_dict["record_id"] = record.get("001").value()
         # Get relevant subfields from the 245 field for the title
-        title_subfields = ["a", "b", "p", "n"]
+        title_subfields = ["a", "b", "n", "p"]
         title_components = record.get("245").get_subfields(*title_subfields)
         record_dict["title"] = " ".join(
             [subfield for subfield in title_components if subfield]

--- a/ftva_lab_data/views_utils.py
+++ b/ftva_lab_data/views_utils.py
@@ -380,17 +380,19 @@ def process_full_alma_data(field_list: list[Field]) -> dict[str, str]:
     for record_field in field_list:
         if record_field.tag not in completed_tags:
             # Get the labels we will use for this tag, guaranteed to be unique
-            # even if there are multiple fields with the same tag.
+            # even if there are multiple fields with the same tag
             labels = get_tag_labels(field_list, record_field.tag)
 
             # Get all other fields from record_fields with the same tag
             current_fields = [f for f in field_list if f.tag == record_field.tag]
-            for i, field in enumerate(current_fields):
-                # Use the label for this field
-                label = labels[i]
-                # Add the field value to the record dict
-                # Assuming we want the format_field() display, which removes subfield delimiters
-                full_record_dict[label] = field.format_field()
+            # Update dict with labels and formatted values
+            # Vaules are formatted with format_field(), which removes subfield delimiters
+            full_record_dict.update(
+                {
+                    labels[i]: field.format_field()
+                    for i, field in enumerate(current_fields)
+                }
+            )
             completed_tags.add(record_field.tag)
 
     return full_record_dict

--- a/ftva_lab_data/views_utils.py
+++ b/ftva_lab_data/views_utils.py
@@ -1,6 +1,7 @@
 import base64
 import binascii
 from typing import Any
+from pymarc import Field
 from django.db.models import Model, Q
 from django.db.models.query import QuerySet
 from django.contrib.auth import authenticate, login
@@ -332,3 +333,64 @@ def basic_auth_required(view_function: Any) -> Any:
             return unauthorized_response
 
     return _wrapped_view
+
+
+def count_tags(fields: list[Field], tag: str) -> int:
+    """Give a list of Pymarc fields, count how many fields have a specific tag.
+
+    :param fields: A list of Pymarc fields to count.
+    :param tag: The tag to count in the fields.
+    :return: The count of fields with the specified tag."""
+
+    return sum(1 for field in fields if field.tag == tag)
+
+
+def get_tag_labels(fields: list[Field], tag: str) -> list[str]:
+    """Get a list of unique labels for a specific tag in a list of Pymarc fields.
+    If there are multiple fields with the same tag, labels will be generated
+    as "Field {tag} #1", "Field {tag} #2", etc.
+    If there is only one field with the tag, the label will be "Field {tag}".
+
+    :param fields: A list of Pymarc fields to process.
+    :param tag: The tag to generate lables for.
+    :return: A list of labels for the specified tag.
+    """
+    count = count_tags(fields, tag)
+    if count == 1:
+        return [f"Field {tag}"]
+    labels = []
+    for i in range(count):
+        labels.append(f"Field {tag} #{i + 1}")
+    return labels
+
+
+def process_full_alma_data(field_list: list[Field]) -> dict[str, str]:
+    """Process a list of Pymarc fields and return a dictionary with processed field tags
+    as unique keys, and formatted Pymarc Field values as their values.
+
+    :param field_list: A list of Pymarc Field objects to process.
+    :return: A dictionary with keys like "Field 100", "Field 200 #1", etc.,
+    and their corresponding formatted values.
+    """
+    # Initialize an empty dictionary to hold the full record data
+    full_record_dict = {}
+    # Keep track of which tags we've completed
+    completed_tags = set()
+
+    for record_field in field_list:
+        if record_field.tag not in completed_tags:
+            # Get the labels we will use for this tag, guaranteed to be unique
+            # even if there are multiple fields with the same tag.
+            labels = get_tag_labels(field_list, record_field.tag)
+
+            # Get all other fields from record_fields with the same tag
+            current_fields = [f for f in field_list if f.tag == record_field.tag]
+            for i, field in enumerate(current_fields):
+                # Use the label for this field
+                label = labels[i]
+                # Add the field value to the record dict
+                # Assuming we want the format_field() display, which removes subfield delimiters
+                full_record_dict[label] = field.format_field()
+            completed_tags.add(record_field.tag)
+
+    return full_record_dict


### PR DESCRIPTION
Implements [SYS-1944](https://uclalibrary.atlassian.net/browse/SYS-1944)

Adds a new view, `get_alma_data()`. This view accepts an inventory number, which is used to get bib data from the Alma SRU interface. Bib data is processed to limit data to the [fields specified by FTVA staff](https://uclalibrary.atlassian.net/wiki/spaces/pm/pages/1305214995/Digital+Data+Preview+fields). The view returns a list of dicts, one for each Alma record, with the following structure:
* `record_id`: bib MMS id, from MARC 001.
* `title`: Work title, taken from MARC 245 by Pymarc `.title`.
* `full_data`: a dict with keys of the form "Field XYZ #n" for repeated fields, and "Field XYZ" for single fields. Values are the full content of the MARC field as a string excluding subfield delimiters, as presented by [Pymarc's format_field()](https://pymarc.readthedocs.io/en/latest/index.html#pymarc.field.Field.format_field).

Tests are added for the new helper functions in `views_utils.py`, bringing the total to 56.

[SYS-1944]: https://uclalibrary.atlassian.net/browse/SYS-1944?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ