### PR TITLE
SYS-1945: Retrieve FM records for an inventory number

### DIFF
--- a/ftva_lab_data/views_utils.py
+++ b/ftva_lab_data/views_utils.py
@@ -409,8 +409,26 @@ def get_specific_filemaker_fields(
     :return: A dict with the specific fields from the Filemaker Record.
     Fields are only included if they exist in the Record.
     """
+    record_fields = fm_record.to_dict()
     return {
-        field: fm_record[field]
-        for field in specific_fields
-        if field in fm_record.to_dict()
+        field: fm_record[field] for field in specific_fields if field in record_fields
     }
+
+
+def transform_filemaker_field_name(filemaker_field_name: str) -> str:
+    """Transforms a filemaker field name to be more friendly and consistent.
+
+    :param str filemaker_field_name: A Filemaker field name.
+    :return: The transformed field name.
+    """
+
+    # Certain field names are acronyms, so return them all caps.
+    # Otherwise, return sentence case with spaces rather than underscores.
+    to_uppercase = ["spac"]
+
+    if filemaker_field_name in to_uppercase:
+        filemaker_field_name = filemaker_field_name.upper()
+    else:
+        filemaker_field_name = filemaker_field_name.replace("_", " ").capitalize()
+
+    return filemaker_field_name

--- a/ftva_lab_data/views_utils.py
+++ b/ftva_lab_data/views_utils.py
@@ -9,6 +9,7 @@ from django.http import HttpResponse, HttpRequest
 from urllib.parse import urlencode
 from .models import SheetImport
 from .forms import ItemForm
+from fmrest.record import Record
 
 
 # Recursive implementation adapted from:
@@ -396,3 +397,20 @@ def process_full_alma_data(field_list: list[Field]) -> dict[str, str]:
             completed_tags.add(record_field.tag)
 
     return full_record_dict
+
+
+def get_specific_filemaker_fields(
+    fm_record: Record, specific_fields: list[str]
+) -> dict:
+    """Gets the provided specific fields from a Filemaker Record instance.
+
+    :param Record fm_record: A fmrest Record instance.
+    :param list[str] specific_fields: A list of specific fields to get from the Record.
+    :return: A dict with the specific fields from the Filemaker Record.
+    Fields are only included if they exist in the Record.
+    """
+    return {
+        field: fm_record[field]
+        for field in specific_fields
+        if field in fm_record.to_dict()
+    }

--- a/project/settings.py
+++ b/project/settings.py
@@ -191,3 +191,9 @@ LOGGING = {
         },
     },
 }
+
+# Secrets
+
+# Credentials for accessing Filemaker API
+FILEMAKER_USER = os.getenv("FILEMAKER_USER")
+FILEMAKER_PASSWORD = os.getenv("FILEMAKER_PASSWORD")


### PR DESCRIPTION
Implements [SYS-1945](https://uclalibrary.atlassian.net/browse/SYS-1945)

### Acceptance criteria
- [x] Write a view which accepts an inventory_number (which will come from the specific DD record the user is on) and uses FilemakerClientto retrieve matching records from Filemaker.

    - [ ] Limit the returned records to 10: either take the first 10 retrieved, or we probably change the client (via separate ticket) to accept a limit.

- [x] For each Filemaker record found, get the specific fields needed (see [list from Thelma](https://uclalibrary.atlassian.net/wiki/x/EwDMTQ))

- [x] Create a search results list of dictionaries, which can be passed to a generic template (to be built later) for display.

    - [ ] If needed, restructure the field data  as key-value pairs which can be passed to a generic template (to be built later) for display.

### Description
This PR adds a new view function: `get_filemaker_data()`. The function accepts an inventory number and returns a list of objects which include Filemaker records matching that inventory number. Only the specific fields that FTVA defined are returned in the `full_data` field of the search result object.

The function mimics the `get_alma_data()` view @ztucker4 added earlier. One difference is that FM credentials are loaded from environment variables using `os.getenv()` in `settings.py`. These are used to establish the FM client instance.

I wasn't sure if I should add the 10-record limit here, or if we'd prefer to do that in `ftva-etl`, so I left that off for now.

I opted not to "prettify" the keys returned in the `full_data` dict quite yet, as I'm not sure what FTVA would prefer, as there's already a mixed style in the field names returned from Filemaker.

### Environment variables
The following environment variables will need to be defined for authentication with the FM client:
```
FILEMAKER_USER={USERNAME HERE}
FILEMAKER_PASSWORD={PW HERE}
```

### Testing
I haven't yet added tests, but can do, if there are certain cases we want to test against.

[SYS-1945]: https://uclalibrary.atlassian.net/browse/SYS-1945?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ