### PR TITLE
SYS-1946: Display external search results

### DIFF
--- a/ftva_lab_data/templates/external_search_results.html
+++ b/ftva_lab_data/templates/external_search_results.html
@@ -1,0 +1,43 @@
+{% extends 'base.html' %}
+
+{% block content %}
+
+<div class="w-75 mx-auto">
+    {% if search_type == "alma" %}
+    <h1>Alma Search Results</h1>
+    {% else %}
+    <h1>Filemaker Search Results</h1>
+    {% endif %}
+</div>
+
+<div class ="d-flex align-items-stretch gap-2 mb-3 w-75 mx-auto">
+    <div class="w-100">
+        <p>Your search for "{{ inventory_number }}" returned {{ records|length }} {{ search_type|title }} records.</p>
+    </div>
+</div>
+<div class="d-flex align-items-stretch gap-2 mb-3 w-75 mx-auto justify-content-start">
+    <div class="w-100">
+        <table class="table table-striped table-hover">
+            <thead>
+                <tr>
+                    <th>Record ID</th>
+                    <th>Title</th>
+                    <th>Actions</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for record in records %}
+                <tr>
+                    <td>{{ record.record_id }}</td>
+                    <td>{{ record.title }}</td>
+                    <!--TODO: button should display external item details-->
+                    <td><a href=# class="btn btn-sm btn-primary">View Record</a></td> 
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+</div>
+
+
+{% endblock %}

--- a/ftva_lab_data/templates/external_search_results.html
+++ b/ftva_lab_data/templates/external_search_results.html
@@ -38,6 +38,4 @@
         </table>
     </div>
 </div>
-
-
 {% endblock %}

--- a/ftva_lab_data/templates/view_item.html
+++ b/ftva_lab_data/templates/view_item.html
@@ -11,14 +11,33 @@
 <div class="container">
     <h1>Item details</h1>
 
-    <p class="fs-5">{% if header_info.file_name %} File: {{ header_info.file_name }} {% endif %}</p>
-    <p class="fs-5">{% if header_info.title %} (Title: {{ header_info.title }}) {% endif %}</p>
-    <p class="fs-5">{% if header_info.id %} Record ID: {{ header_info.id }} {% endif %}</p>
-    <p class="fs-5">{% if header_info.status %} Status: 
-        {% for status in header_info.status %}
-            <span class="badge rounded-pill bg-info text-dark m-1">{{ status }}</span>
-        {% endfor %}
-    {% endif %}</p>
+    <div class="d-flex justify-content-between align-items-start mb-3">
+        <div>
+            <p class="fs-5 mb-1">{% if header_info.file_name %} File: {{ header_info.file_name }} {% endif %}</p>
+            <p class="fs-5 mb-1">{% if header_info.title %} (Title: {{ header_info.title }}) {% endif %}</p>
+            <p class="fs-5 mb-1">{% if header_info.id %} Record ID: {{ header_info.id }} {% endif %}</p>
+            <p class="fs-5 mb-1">{% if header_info.status %} Status: 
+                {% for status in header_info.status %}
+                    <span class="badge rounded-pill bg-info text-dark m-1">{{ status }}</span>
+                {% endfor %}
+            {% endif %}</p>
+        </div>
+        {% if header_info.inventory_number %}
+            <div class="d-flex flex-column align-items-end gap-2">
+                <a class="btn btn-secondary"
+                    href="{% url 'get_external_search_results' search_type='alma' inventory_number=header_info.inventory_number %}"
+                    target="_blank">
+                        View Alma Records
+                </a>
+                <a class="btn btn-secondary"
+                    href="{% url 'get_external_search_results' search_type='fm' inventory_number=header_info.inventory_number %}"
+                    target="_blank">
+                        View Filemaker Records
+                </a>
+            </div>
+        {% endif %}
+
+    </div>
 
     <!-- Buttons -->
     <div class="d-flex justify-content-between mb-3">

--- a/ftva_lab_data/urls.py
+++ b/ftva_lab_data/urls.py
@@ -17,4 +17,9 @@ urlpatterns = [
     path("logs/<int:line_count>", views.show_log, name="show_log"),
     path("release_notes/", views.release_notes, name="release_notes"),
     path("records/<int:record_id>/", views.get_record, name="get_record"),
+    path(
+        "external_search_results/<str:search_type>/<str:inventory_number>/",
+        views.get_external_search_results,
+        name="get_external_search_results",
+    ),
 ]

--- a/ftva_lab_data/views.py
+++ b/ftva_lab_data/views.py
@@ -397,7 +397,7 @@ def get_record(request: HttpRequest, record_id: int) -> JsonResponse:
         return JsonResponse({"error": "Record not found"}, status=404)
 
 
-def get_alma_data(request: HttpRequest, inventory_number: str) -> list[dict]:
+def get_alma_data(request: HttpRequest, inventory_number: str) -> HttpResponse:
     """Fetch Alma records using SRU client.
 
     :param request: The HTTP request object.
@@ -429,6 +429,37 @@ def get_alma_data(request: HttpRequest, inventory_number: str) -> list[dict]:
 
         full_data_dicts.append(record_dict)
 
-    # TODO: return a template with the records
-    # For now, just return the list of dictionaries
-    return full_data_dicts
+    return render(
+        request,
+        "external_search_results.html",
+        {
+            "records": full_data_dicts,
+            "inventory_number": inventory_number,
+            "search_type": "alma",
+        },
+    )
+
+
+def get_external_search_results(
+    request: HttpRequest, inventory_number: str, search_type: str
+) -> HttpResponse:
+    """Fetch external search results for a given inventory number.
+
+    :param request: The HTTP request object.
+    :param inventory_number: The inventory number to search for.
+    :return: Rendered HTML for the external search results.
+    """
+    if search_type == "alma":
+        return get_alma_data(request, inventory_number)
+
+    elif search_type == "fm":
+        # TODO: add Filemaker search view
+        return HttpResponse(
+            "FM search functionality is not yet implemented.",
+            status=501,
+        )
+    else:
+        return HttpResponse(
+            "Invalid search type specified.",
+            status=400,
+        )

--- a/ftva_lab_data/views_utils.py
+++ b/ftva_lab_data/views_utils.py
@@ -58,6 +58,8 @@ def get_item_display_dicts(item: SheetImport) -> dict[str, Any]:
         "title": item.title,
         "status": [str(status) for status in item.status.all()],
         "id": item.id,
+        # For use in external search links
+        "inventory_number": item.inventory_number,
     }
     storage_info = {
         "Hard Drive Name": item.hard_drive_name,


### PR DESCRIPTION
Implements [SYS-1946](https://uclalibrary.atlassian.net/browse/SYS-1946)

Adds a new template, `external_search_results.html`, with a corresponding view. The template is intended to support both Alma and Filemaker data.

Items with an Inventory Number value should have a two new buttons visible in the top right for Alma and Filemaker search results. Both buttons should open a new tab when clicked, and the Alma button should display search results. 

<img width="1392" height="554" alt="image" src="https://github.com/user-attachments/assets/d384b233-53e1-42e8-a0d6-7a4927b8a24b" />
<img width="1392" height="273" alt="image" src="https://github.com/user-attachments/assets/769c4b94-0487-4d64-8621-553a6cf333cc" />

Note for the FM implementation: The FM view will need to return an `inventory_number` and a `search_type` in its context, as these are used in the template and the generic `get_external_search_results` view. The view assumes the `search_type` is either "alma" or "fm".



