### PR TITLE
SYS-1947: Add record details modal to external search results view

### DIFF
--- a/ftva_lab_data/templates/external_search_results.html
+++ b/ftva_lab_data/templates/external_search_results.html
@@ -30,9 +30,20 @@
                 <tr>
                     <td>{{ record.record_id }}</td>
                     <td>{{ record.title }}</td>
-                    <!--TODO: button should display external item details-->
-                    <td><a href=# class="btn btn-sm btn-primary">View Record</a></td> 
+                    <td>
+                        <button 
+                            type="button" 
+                            class="btn btn-sm btn-primary"
+                            data-bs-toggle="modal"
+                            data-bs-target="#record-modal-{{ forloop.counter }}">
+                            View Record
+                        </button>
+                    </td> 
                 </tr>
+                {% comment %} Include a modal for each record, 
+                passing the record and the modal index as variables.
+                {% endcomment %}
+                {% include "partials/external_record_modal.html" with record=record modal_index=forloop.counter %}
                 {% endfor %}
             </tbody>
         </table>

--- a/ftva_lab_data/templates/partials/external_record_modal.html
+++ b/ftva_lab_data/templates/partials/external_record_modal.html
@@ -1,0 +1,28 @@
+<div class="modal fade" id="record-modal-{{ modal_index }}" tabindex="-1">
+    <div class="modal-dialog modal-lg modal-dialog-scrollable modal-dialog-centered">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Record Details</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <div class="modal-body">
+                <h6 class="text-muted">Record ID: {{ record.record_id }}</h6>
+                <h5 class="mb-3">{{ record.title }}</h5>
+                
+                {% if record.full_data %}
+                    <dl class="row">
+                        {% for key, value in record.full_data.items %}
+                            <dt class="col-sm-4">{{ key }}</dt>
+                            <dd class="col-sm-8">{{ value }}</dd>
+                        {% endfor %}
+                    </dl>
+                {% else %}
+                    <p class="text-muted">No record details available.</p>
+                {% endif %}
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+            </div>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
Implements [SYS-1947](https://uclalibrary.atlassian.net/browse/SYS-1947)

### Acceptance criteria
- [x] Create a template which displays a record from Alma or Filemaker (see linked tickets).
- [x] The template should display a simple list of the key / value pairs from the dictionary.
- [x] The template will display as an overlay on the search results page (see linked ticket), as a bootstrap scrollable overlay (I think we decided).
- [x] Closing the template will leave the user viewing the same search results page as when the template was opened.  No other navigation is required.

### Description
This PR adds a record detail modal to the external search results display. The user can now click on the `View Record` button(s) within the external search results table and launch a modal with the key-value pairs for that record displayed in a scrollable overlay, provided by Bootstrap.

Markup for all the modals is loaded with the initial page load. This should be acceptable for the number of records we're dealing with, keeping all data provided by a single view function and reducing the need to involve HTMX. It does however push some logic into the template. I think it is an acceptable amount of logic in the template, mostly just involving for loops. The modal markup is loaded using Django's `{% include %}`, passing two variables in that statement: the record for the current table row and a modal index that allows Bootstrap to launch the right modal for the record at hand.

Let me know if this is too much logic to put into the template, and I can find a different approach using a new view and HTMX.

[SYS-1947]: https://uclalibrary.atlassian.net/browse/SYS-1947?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ