### PR TITLE
SYS-1949: Add view to generate metadata JSON

### DIFF
--- a/ftva_lab_data/urls.py
+++ b/ftva_lab_data/urls.py
@@ -22,4 +22,9 @@ urlpatterns = [
         views.get_external_search_results,
         name="get_external_search_results",
     ),
+    path(
+        "metadata_json/<int:record_id>/<str:inventory_number>/",
+        views.generate_metadata_json,
+        name="generate_metadata_json",
+    ),
 ]

--- a/ftva_lab_data/urls.py
+++ b/ftva_lab_data/urls.py
@@ -23,7 +23,7 @@ urlpatterns = [
         name="get_external_search_results",
     ),
     path(
-        "metadata_json/<int:record_id>/<str:inventory_number>/",
+        "metadata_json/<int:record_id>/",
         views.generate_metadata_json,
         name="generate_metadata_json",
     ),

--- a/ftva_lab_data/views_utils.py
+++ b/ftva_lab_data/views_utils.py
@@ -434,3 +434,27 @@ def transform_filemaker_field_name(filemaker_field_name: str) -> str:
         filemaker_field_name = filemaker_field_name.replace("_", " ").capitalize()
 
     return filemaker_field_name
+
+
+def transform_record_to_dict(record_id: int) -> dict:
+    """Transforms a Django record to a dictionary.
+
+    :param int record_id: The ID of the record to transform.
+    :return: A dictionary with the record data.
+    """
+
+    record = SheetImport.objects.get(id=record_id)
+    record_data = {
+        field.name: getattr(record, field.name) for field in record._meta.fields
+    }
+    # Add Status many-to-many field data
+    record_data["status"] = [status.status for status in record.status.all()]
+    # Add Assigned User data if it exists
+    if record.assigned_user:
+        record_data["assigned_user"] = {
+            "id": record.assigned_user.id,
+            "username": record.assigned_user.username,
+            "full_name": record.assigned_user.get_full_name(),
+        }
+
+    return record_data


### PR DESCRIPTION
Implements [SYS-1949](https://uclalibrary.atlassian.net/browse/SYS-1949)

### Acceptance criteria
- [x] A new view takes the current record’s inventory_numberas a parameter.
- [x] The view uses the `ftva_etl` package to retrieve both Alma and Filemaker records with that inventory number.
- [x] If both Alma and Filemaker searches return exactly one record each, pass Alma / Filemaker / Digital Data records to the ETL package’s `get_mams_metadata()` function.
- [x] If either Alma or Filemaker searches returns other than exactly one record each, return a dictionary with useful error message(s), for now, maybe like the below.

### Description
This PR adds a view to generate a combined metadata record in JSON, using records retrieved from Alma, Filemaker, and Django. The view takes in a `record_id` referring to the Django record to use as the "base" for the metadata generation, then an `inventory_number` to use to retrieve records from Alma and Filemaker. If there is exactly one record each retrieved from Alma and Filemaker, these are joined with the Django record using the `get_mams_metadata()` from the `ftva_etl` package. Otherwise, a message is returned.

`TODO` notes are included for the return statements that will eventually render templates.

### Testing
I didn't add any automated tests, but using the recent production data dump in a local instance, the following URL should provide an example of a 1-1-1 record that returns a joined JSON record: http://localhost:8000/metadata_json/106/M190816/. The Django `record_id` and `inventory_number` are the second-to-last and last URL components respectively.

[SYS-1949]: https://uclalibrary.atlassian.net/browse/SYS-1949?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ