### PR TITLE
SYS-1950: Display metadata JSON

### DIFF
--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: "0.1"
 description: Chart for FTVA Lab Data application
 name: ftva-lab-data
-version: 1.0.0
+version: 1.0.1

--- a/charts/prod-ftvalabdata-values.yaml
+++ b/charts/prod-ftvalabdata-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/ftva-lab-data
-  tag: v1.0.5
+  tag: v1.0.6
   pullPolicy: Always
 
 nameOverride: ""
@@ -58,6 +58,8 @@ django:
       # Application database used by django
       db_password: "/systems/prodrke01/ftva-lab-data/db_password"
       django_secret_key: "/systems/prodrke01/ftva-lab-data/django_secret_key"
+      filemaker_password: "/systems/prodrke01/ftva-lab-data/filemaker_password"
+      filemaker_user: "/systems/prodrke01/ftva-lab-data/filemaker_user"
 
 # Memory request and limit both set to 1Gi to deal with out of memory
 # errors when running full CSV export.

--- a/charts/templates/externalsecret.yaml
+++ b/charts/templates/externalsecret.yaml
@@ -21,3 +21,9 @@ spec:
     - secretKey: "DJANGO_DB_PASSWORD"
       remoteRef:
         key: {{ .Values.django.externalSecrets.env.db_password }}
+    - secretKey: "FILEMAKER_PASSWORD"
+      remoteRef:
+        key: {{ .Values.django.externalSecrets.env.filemaker_password }}
+    - secretKey: "FILEMAKER_USER"
+      remoteRef:
+        key: {{ .Values.django.externalSecrets.env.filemaker_user }}

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -56,7 +56,9 @@ django:
     # Include below if enabled: "true"
     #  db_password: ""
     #  django_secret_key: ""
-  
+    #  filemaker_password: ""
+    #  filemaker_user: ""
+
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/ftva_lab_data/templates/partials/metadata_modal.html
+++ b/ftva_lab_data/templates/partials/metadata_modal.html
@@ -1,0 +1,32 @@
+<div class="modal-content">
+    <div class="modal-header">
+        <h1 class="modal-title">
+            {% if is_error %}
+            Metadata Error
+            {% else %}
+            JSON Metadata for {{ inventory_number }}
+            {% endif %}
+        </h1>
+        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+    </div>
+    <div class="modal-body">
+        {% if is_error %}
+        <div class="alert alert-danger">
+            <h6 class="alert-heading">Error</h6>
+            <p class="mb-0">{{ message }}</p>
+        </div>
+        {% else %}
+        <div class="mb-3">
+            <h6 class="text-muted">Record ID: {{ record_id }}</h6>
+            <h6 class="text-muted">Inventory Number: {{ inventory_number }}</h6>
+        </div>
+        <div class="bg-light p-3 rounded">
+            <pre class="mb-0"
+                style="white-space: pre-wrap; word-wrap: break-word; font-size: 0.9em;">{{ metadata|pprint }}</pre>
+        </div>
+        {% endif %}
+    </div>
+    <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+    </div>
+</div>

--- a/ftva_lab_data/templates/partials/metadata_modal_content.html
+++ b/ftva_lab_data/templates/partials/metadata_modal_content.html
@@ -1,18 +1,18 @@
 <div class="modal-content">
     <div class="modal-header">
-        <h1 class="modal-title">
+        <h5 class="modal-title">
             {% if is_error %}
             Metadata Error
             {% else %}
-            JSON Metadata for {{ inventory_number }}
+            Metadata JSON for {{ inventory_number }}
             {% endif %}
-        </h1>
+        </h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
     </div>
     <div class="modal-body">
         {% if is_error %}
-        <div class="alert alert-danger">
-            <h6 class="alert-heading">Error</h6>
+        <div class="alert alert-warning">
+            <h6 class="alert-heading">Warning</h6>
             <p class="mb-0">{{ message }}</p>
         </div>
         {% else %}
@@ -22,7 +22,7 @@
         </div>
         <div class="bg-light p-3 rounded">
             <pre class="mb-0"
-                style="white-space: pre-wrap; word-wrap: break-word; font-size: 0.9em;">{{ metadata|pprint }}</pre>
+                style="white-space: pre-wrap; word-wrap: break-word; font-size: 0.9em;">{{ metadata_json }}</pre>
         </div>
         {% endif %}
     </div>

--- a/ftva_lab_data/templates/release_notes.html
+++ b/ftva_lab_data/templates/release_notes.html
@@ -4,6 +4,14 @@
 <h3>Release Notes</h3>
 <hr/>
 
+<h4>1.0.6</h4>
+<p><i>August 7, 2025</i></p>
+<ul>
+    <li>Added ability to see Alma and Filemaker records matching current inventory number.</li>
+    <li>Added ability to see JSON metadata associated with current record, including Alma and Filemaker data.</li>
+    <li>Added /records/record_id endpoint to allow external programs to retrieve Digital Data records.</li>
+</ul>
+
 <h4>1.0.5</h4>
 <p><i>July 25, 2025</i></p>
 <ul>

--- a/ftva_lab_data/templates/view_item.html
+++ b/ftva_lab_data/templates/view_item.html
@@ -35,6 +35,10 @@
                 target="_blank">
                 View Filemaker Records
             </a>
+            {% comment %}
+            This button uses Bootstrap to open the metadata modal
+            and HTMX to swap the modal content when the request completes.
+            {% endcomment %}
             <button class="btn btn-secondary" data-bs-toggle="modal" data-bs-target="#metadata-modal"
                 hx-get="{% url 'generate_metadata_json' header_info.id %}" hx-target="#metadata-modal-content"
                 hx-trigger="click">
@@ -125,10 +129,13 @@
     </div>
 </div>
 
+{% comment %}
+The modal will show a loading state when first opened. 
+HTMX will swap `#metadata-modal-content` when the request completes.
+{% endcomment %}
 <div class="modal fade" id="metadata-modal" tabindex="-1">
     <div class="modal-dialog modal-lg modal-dialog-scrollable modal-dialog-centered">
-        {% comment %} This is a loading state. HTMX will swap modal content when request completes {% endcomment %}
-        <div class="modal-content">
+        <div class="modal-content" id="metadata-modal-content">
             <div class="modal-header">
                 <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
             </div>

--- a/ftva_lab_data/templates/view_item.html
+++ b/ftva_lab_data/templates/view_item.html
@@ -16,25 +16,31 @@
             <p class="fs-5 mb-1">{% if header_info.file_name %} File: {{ header_info.file_name }} {% endif %}</p>
             <p class="fs-5 mb-1">{% if header_info.title %} (Title: {{ header_info.title }}) {% endif %}</p>
             <p class="fs-5 mb-1">{% if header_info.id %} Record ID: {{ header_info.id }} {% endif %}</p>
-            <p class="fs-5 mb-1">{% if header_info.status %} Status: 
+            <p class="fs-5 mb-1">{% if header_info.status %} Status:
                 {% for status in header_info.status %}
-                    <span class="badge rounded-pill bg-info text-dark m-1">{{ status }}</span>
+                <span class="badge rounded-pill bg-info text-dark m-1">{{ status }}</span>
                 {% endfor %}
-            {% endif %}</p>
+                {% endif %}
+            </p>
         </div>
         {% if header_info.inventory_number %}
-            <div class="d-flex flex-column align-items-end gap-2">
-                <a class="btn btn-secondary"
-                    href="{% url 'get_external_search_results' search_type='alma' inventory_number=header_info.inventory_number %}"
-                    target="_blank">
-                        View Alma Records
-                </a>
-                <a class="btn btn-secondary"
-                    href="{% url 'get_external_search_results' search_type='fm' inventory_number=header_info.inventory_number %}"
-                    target="_blank">
-                        View Filemaker Records
-                </a>
-            </div>
+        <div class="d-flex flex-column align-items-end gap-2">
+            <a class="btn btn-secondary"
+                href="{% url 'get_external_search_results' search_type='alma' inventory_number=header_info.inventory_number %}"
+                target="_blank">
+                View Alma Records
+            </a>
+            <a class="btn btn-secondary"
+                href="{% url 'get_external_search_results' search_type='fm' inventory_number=header_info.inventory_number %}"
+                target="_blank">
+                View Filemaker Records
+            </a>
+            <button class="btn btn-secondary" data-bs-toggle="modal" data-bs-target="#metadata-modal"
+                hx-get="{% url 'generate_metadata_json' header_info.id %}" hx-target="#metadata-modal-content"
+                hx-trigger="click">
+                View Metadata
+            </button>
+        </div>
         {% endif %}
 
     </div>
@@ -45,16 +51,14 @@
             <button id="toggle-advanced-fields" class="btn btn-secondary" type="button"
                 hx-on:click="toggleAdvancedFields(this)">Show Advanced Fields</button>
             {% if perms.ftva_lab_data.change_sheetimport %}
-            <a class="btn btn-primary"
-            href="{% url 'edit_item' header_info.id %}?{{ url_parameters }}">
-            Edit This Record
+            <a class="btn btn-primary" href="{% url 'edit_item' header_info.id %}?{{ url_parameters }}">
+                Edit This Record
             </a>
             {% endif %}
         </div>
 
-        <a class="btn btn-outline-secondary"
-        href="{% url 'search_results' %}?{{ url_parameters }}">
-        Back to Search
+        <a class="btn btn-outline-secondary" href="{% url 'search_results' %}?{{ url_parameters }}">
+            Back to Search
         </a>
     </div>
 
@@ -65,9 +69,9 @@
                 <div class="card-body">
                     <h5 class="card-title">Storage Information </h5>
                     {% for header, data in storage_info.items %}
-                        {% if data %}
-                            <p class="card-text"><strong>{{ header }}:</strong> {{ data }}</p>
-                        {% endif %}
+                    {% if data %}
+                    <p class="card-text"><strong>{{ header }}:</strong> {{ data }}</p>
+                    {% endif %}
                     {% endfor %}
                 </div>
             </div>
@@ -78,10 +82,10 @@
                 <div class="card-body">
                     <h5 class="card-title">File Information</h5>
                     {% for header, data in file_info.items %}
-                        {% if data %}
-                            <p class="card-text"><strong>{{ header }}:</strong> {{ data }}</p>
-                        {% endif %}
-                    {% endfor %}    
+                    {% if data %}
+                    <p class="card-text"><strong>{{ header }}:</strong> {{ data }}</p>
+                    {% endif %}
+                    {% endfor %}
                 </div>
             </div>
         </div>
@@ -91,9 +95,9 @@
                 <div class="card-body">
                     <h5 class="card-title">Inventory Information</h5>
                     {% for header, data in inventory_info.items %}
-                        {% if data %}
-                            <p class="card-text"><strong>{{ header }}:</strong> {{ data }}</p>
-                        {% endif %}
+                    {% if data %}
+                    <p class="card-text"><strong>{{ header }}:</strong> {{ data }}</p>
+                    {% endif %}
                     {% endfor %}
                 </div>
             </div>
@@ -106,16 +110,36 @@
             <div class="card-body row">
                 <div class="col">
                     {% for header, data in advanced_info.items %}
-                        {% if data %}
-                            <p class="card-text"><strong>{{ header }}:</strong> {{ data }}</p>
-                        {% endif %}
-                        <!--- New div after 18 rows of data-->
-                        {% if forloop.counter == 19 %}
-                            </div>
-                            <div class="col">
-                        {% endif %}
+                    {% if data %}
+                    <p class="card-text"><strong>{{ header }}:</strong> {{ data }}</p>
+                    {% endif %}
+                    <!--- New div after 18 rows of data-->
+                    {% if forloop.counter == 19 %}
+                </div>
+                <div class="col">
+                    {% endif %}
                     {% endfor %}
                 </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="metadata-modal" tabindex="-1">
+    <div class="modal-dialog modal-lg modal-dialog-scrollable modal-dialog-centered">
+        {% comment %} This is a loading state. HTMX will swap modal content when request completes {% endcomment %}
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <div class="modal-body">
+                <div class="d-flex align-items-center justify-content-center gap-2">
+                    <div class="spinner-border"></div>
+                    <div>Loading...</div>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
             </div>
         </div>
     </div>

--- a/ftva_lab_data/views.py
+++ b/ftva_lab_data/views.py
@@ -10,6 +10,7 @@ from django.urls import reverse
 from ftva_etl import AlmaSRUClient, FilemakerClient, get_mams_metadata
 import pandas as pd
 import io
+import json
 
 from .forms import ItemForm
 from .models import SheetImport
@@ -532,7 +533,7 @@ def generate_metadata_json(request: HttpRequest, record_id: int) -> HttpResponse
         message = f"No inventory number found for record {record_id}."
         return render(
             request,
-            "partials/metadata_modal.html",
+            "partials/metadata_modal_content.html",
             {
                 "message": message,
                 "is_error": True,
@@ -554,11 +555,13 @@ def generate_metadata_json(request: HttpRequest, record_id: int) -> HttpResponse
     # If Alma and FM records are unique, generate JSON metadata
     if bib_records_count == 1 and fm_records_count == 1:
         metadata = get_mams_metadata(bib_records[0], fm_records[0], django_record_data)
+        # Format the metadata as JSON for display in the template
+        metadata_json = json.dumps(metadata, indent=2)
         return render(
             request,
-            "partials/metadata_modal.html",
+            "partials/metadata_modal_content.html",
             {
-                "metadata": metadata,
+                "metadata_json": metadata_json,
                 "inventory_number": inventory_number,
                 "record_id": record_id,
             },
@@ -573,6 +576,6 @@ def generate_metadata_json(request: HttpRequest, record_id: int) -> HttpResponse
     # Render a template with the message.
     return render(
         request,
-        "partials/metadata_modal.html",
+        "partials/metadata_modal_content.html",
         {"message": message, "is_error": True},
     )


### PR DESCRIPTION
Implements [SYS-1950](https://uclalibrary.atlassian.net/browse/SYS-1950)

### Acceptance criteria
- [x] A new template displays the JSON  (or Python dict) metadata, or error, from the view created in SYS-1949
- [x] This template should be a modal, similar to the one used for external record displays
- [x] This template (and the underlying view) should be triggered by clicking a “View metadata” button added to the `view_item` template, under the Alma/Filemaker buttons

### Description
This PR adds a template to make use of the view added in SYS-1949 (#63). A template partial called `metadata_modal_content.html` is added, which is loaded by HTMX when the "View metadata" button is clicked on the view item page. HTMX swaps in the template partial to the modal added to `view_item.html`, which includes a loading indicator. Bootstrap handles the opening and styling of the modal. Successful requests which result in 1-1-1 records display the joined metadata as JSON (formatted in the view), while non-unique results show a warning message.

[SYS-1950]: https://uclalibrary.atlassian.net/browse/SYS-1950?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ