### PR TITLE
SYS-1977: Fix metadata display bug caused by UUID

### DIFF
--- a/charts/prod-ftvalabdata-values.yaml
+++ b/charts/prod-ftvalabdata-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/ftva-lab-data
-  tag: v1.0.9
+  tag: v1.0.10
   pullPolicy: Always
 
 nameOverride: ""

--- a/ftva_lab_data/templates/release_notes.html
+++ b/ftva_lab_data/templates/release_notes.html
@@ -4,6 +4,12 @@
 <h3>Release Notes</h3>
 <hr/>
 
+<h4>1.0.10</h4>
+<p><i>August 21, 2025</i></p>
+<ul>
+    <li>Fix metadata display bug caused by unserializable UUID data type.</li>
+</ul>
+
 <h4>1.0.9</h4>
 <p><i>August 20, 2025</i></p>
 <ul>

--- a/ftva_lab_data/views_utils.py
+++ b/ftva_lab_data/views_utils.py
@@ -463,5 +463,8 @@ def transform_record_to_dict(record_id: int) -> dict:
             "username": record.assigned_user.username,
             "full_name": record.assigned_user.get_full_name(),
         }
+    # Convert UUID to string, as UUID object is not JSON-serializable and
+    # will be needed for that later.
+    record_data["uuid"] = str(record_data["uuid"])
 
     return record_data


### PR DESCRIPTION
Fixes [SYS-1977](https://uclalibrary.atlassian.net/browse/SYS-1977).  Tagged as `v1.0.10` for deployment.

This PR fixes a bug which prevented the JSON metadata from displaying.  The bug was caused by the `UUID()` data type being included in the Django dictionary generated by `views_utils.transform_record_to_dict()`.  The `uuid` field, which has a type of `UUID()`, could not be serialized to JSON by `json.dumps()`, raising a `TypeError`.

Since we only need the value and not the object itself, I cast `uuid` to a string, which fixes the bug.  I also added a test case to cover this.

`docker compose exec django python manage.py test` now runs 58 tests, all passing.


[SYS-1977]: https://uclalibrary.atlassian.net/browse/SYS-1977?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ