### PR TITLE
SYS-1983: Add support for production database imports

### DIFF
--- a/.docker-compose_db.env
+++ b/.docker-compose_db.env
@@ -12,8 +12,8 @@
 DJANGO_DB_BACKEND=django.db.backends.postgresql
 DJANGO_DB_HOST=db
 DJANGO_DB_PORT=5432
-DJANGO_DB_NAME=ftva_lab_data
-DJANGO_DB_USER=ftva_lab_data
+DJANGO_DB_NAME=ftva-digital-data
+DJANGO_DB_USER=ftva-digital-data
 DJANGO_DB_PASSWORD=dev_password
 
 # PostgreSQL container requires specific variable names

--- a/.gitignore
+++ b/.gitignore
@@ -183,4 +183,9 @@ cython_debug/
 staticfiles/
 
 # Data files
+*.csv
 *.xlsx
+
+# Backup files
+*.tar
+*.tar.gz

--- a/README.md
+++ b/README.md
@@ -89,7 +89,20 @@ The container runs via `docker_scripts/entrypoint.sh`, which
 
    ```$ docker compose down```
 
+### Importing production database
+
+**Note**: This will fully replace your local development database.
+
+1. Get a copy of a recent database dump, either from a teammate or by opening a ticket with the Digital Infrastructure team.  The database dump is from nightly production backups, and is delivered as a compressed archive containing multiple files, like `pg_ftva-digital-data-2025-08-26.d.tar.gz`.  This file can be placed anywhere, like `/tmp/`, and does not need to be in your project directory.
+2. Start your development system, and wait for the database to be available: `docker compose up -d`
+3. Run: `docker_scripts/import_prod_db.sh /path/to/database_dump_file.tar.gz`
+4. Within a few seconds, you should see a long list of messages from `pg_restore`.  If no errors, all went correctly.
+
+This will copy the dump file to the database container, unpack it, and import it, replacing all content in the original database.
+
 ### Loading data
+
+**Note**: None of these steps are necessary for development.  These are scripts and Django management commands which were used for specific data transformations, documented here for reference.
 
 #### Converting data for import
 

--- a/docker_scripts/import_prod_db.sh
+++ b/docker_scripts/import_prod_db.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+if [ -z "$1" ]; then
+    echo Usage: $0 db_dump_file.tar.gz
+    exit 1
+else
+    DB_FILE="$1"
+fi
+
+# Load local db info from .docker-compose_db.env
+# DB user and DB name need to be the same as they are in production.
+source .docker-compose_db.env
+
+# Copy the db dump file to the running database container.
+docker compose cp "${DB_FILE}" db:/tmp
+
+# Build command to run inside container.
+UNTAR_COMMAND="cd /tmp && tar xf ${DB_FILE}"
+# DB_FILE variable value must be passed to docker compose.
+docker compose exec -e DB_FILE="${DB_FILE}" db bash -c "${UNTAR_COMMAND}"
+
+# Build command to run inside container.
+DB_DIR=`basename "${DB_FILE}" .tar.gz`
+PG_COMMAND="pg_restore --verbose --if-exists --clean -U ${POSTGRES_USER} -d ${POSTGRES_DB} /tmp/${DB_DIR}"
+# DB_DIR variable value must be passed to docker compose.
+docker compose exec -e DB_DIR="${DB_DIR}" db bash -c "${PG_COMMAND}"


### PR DESCRIPTION
Implements [SYS-1983](https://uclalibrary.atlassian.net/browse/SYS-1983).  Development environment only, no deployment needed.

This PR adds support for importing production database dumps into the local development environment.  Documentation has been added to `README.md` in a new "Importing production database" section.

A few extra steps are needed here, the first time this is done: the development database user name and database name must be identical to production.  I've updated `.docker-compose_db.yml` to match.  This requires dropping your existing local database volume, to get rid of the old database and user names.

1. When ready, get a copy of the latest database dump from @akohler 
2. Shut down local system.
3. Delete database volume.
4. Start up local system and wait for database to be ready.
5. Run the import script.

```
# 1: Get pg_ftva-digital-data-2025-08-26.d.tar.gz and put it anywhere you like; I'm using /tmp/
ls -l /tmp/pg_ftva-digital-data-2025-08-26.d.tar.gz
-rw-r--r-- 1 akohler akohler 5054717 Aug 26 11:52 /tmp/pg_ftva-digital-data-2025-08-26.d.tar.gz

# 2: Shut down local system
docker compose down

# 3: Delete database volume
docker volume rm ftva-lab-data_pg_data

# 4: Start up local system and wait for database to be ready
docker compose up -d
docker compose logs -f db
# wait until you see: database system is ready to accept connections

# 5: Run the import script
docker_scripts/import_prod_db.sh /tmp/pg_ftva-digital-data-2025-08-26.d.tar.gz
# should just take a few seconds, ending with message like

pg_restore: creating FK CONSTRAINT "public.ftva_lab_data_sheetimport_status ftva_lab_data_sheeti_sheetimport_id_aaf20be3_fk_ftva_lab_"
```


[SYS-1983]: https://uclalibrary.atlassian.net/browse/SYS-1983?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ