### PR TITLE
Change CPU resource limit to remove memory limitation

### DIFF
--- a/charts/prod-ftvalabdata-values.yaml
+++ b/charts/prod-ftvalabdata-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/ftva-lab-data
-  tag: v1.0.16
+  tag: v1.0.17
   pullPolicy: Always
 
 nameOverride: ""
@@ -71,7 +71,7 @@ django:
 # errors when running full CSV export.
 resources:
   limits:
-    cpu: 500m
+    cpu: 2
     memory: 1Gi
   requests:
     cpu: 250m


### PR DESCRIPTION
Change CPU resource limitation from `500m` (memory bounded) to `2` (cores).  Per @cachemeoutside this should allow the pod to allocate resources for burst activities, like complex database updates.
