### PR TITLE
SYS-2028: Fix database import script

### DIFF
--- a/docker_scripts/import_prod_db.sh
+++ b/docker_scripts/import_prod_db.sh
@@ -19,8 +19,9 @@ UNTAR_COMMAND="cd /tmp && tar xf ${DB_FILE}"
 # DB_FILE variable value must be passed to docker compose.
 docker compose exec -e DB_FILE="${DB_FILE}" db bash -c "${UNTAR_COMMAND}"
 
+# Directory name is the first entry in the tar archive.
+DB_DIR=`tar tf "${DB_FILE}" | head -1`
 # Build command to run inside container.
-DB_DIR=`basename "${DB_FILE}" .tar.gz`
 PG_COMMAND="pg_restore --verbose --if-exists --clean -U ${POSTGRES_USER} -d ${POSTGRES_DB} /tmp/${DB_DIR}"
 # DB_DIR variable value must be passed to docker compose.
 docker compose exec -e DB_DIR="${DB_DIR}" db bash -c "${PG_COMMAND}"


### PR DESCRIPTION
Fixes [SYS-2028](https://uclalibrary.atlassian.net/browse/SYS-2028).  Developer only, no deployment needed.

This fixes a minor issue with the database import script, caused by a change in the database archive naming convention.  The script assumed that the name of the unpacked database directory was the same as the name of the archive itself, with the terminal `.tar.gz` removed.  The updated script now gets the name of the directory from within the archive, by doing a `tar tf archive_name` (to list the contents) and piping that to `head -1` to get the first entry, which is the directory name.

```
$ tar tf /tmp/pg_ftva-digital-data-2025-09-19.tar.gz
pg_ftva-digital-data-2025-09-19.d/  # <--- this is the directory name
pg_ftva-digital-data-2025-09-19.d/toc.dat
pg_ftva-digital-data-2025-09-19.d/3521.dat.gz
[list of file snipped]
```

### Testing

Get the new db dump from Slack and run this script.  Production db should be imported as before, with no errors.

```
docker compose up -d
# wait for db to be available
docker_scripts/import_prod_db.sh /tmp/pg_ftva-digital-data-2025-09-19.tar.gz
```


[SYS-2028]: https://uclalibrary.atlassian.net/browse/SYS-2028?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ