### PR TITLE
DLSR-276: update ftva-etl package version

### DIFF
--- a/charts/prod-ftvalabdata-values.yaml
+++ b/charts/prod-ftvalabdata-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/ftva-lab-data
-  tag: v1.1.0
+  tag: v1.1.1
   pullPolicy: Always
 
 nameOverride: ""

--- a/ftva_lab_data/templates/release_notes.html
+++ b/ftva_lab_data/templates/release_notes.html
@@ -4,6 +4,12 @@
 <h3>Release Notes</h3>
 <hr />
 
+<h4>1.1.1</h4>
+<p><i>April 8, 2026</i></p>
+<ul>
+    <li>Update FTVA ETL package to use new Filemaker API layout.</li>
+</ul>
+
 <h4>1.1.0</h4>
 <p><i>March 26, 2026</i></p>
 <ul>

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ pandas==2.2.3
 numpy==2.3.5
 openpyxl==3.1.5
 # Local package for Alma & Filemaker integration.
-git+https://github.com/UCLALibrary/ftva-etl.git@v0.3.0
+git+https://github.com/UCLALibrary/ftva-etl.git@v0.3.1


### PR DESCRIPTION
Implements [DLSR-276](https://uclalibrary.atlassian.net/browse/DLSR-276)

One small change to `requirements.txt` to bring in the latest version of the `ftva-etl` package, recently updated to correct the default Filemaker layout name.

This PR should be tested and merged after the corresponding `ftva-etl` PR (https://github.com/UCLALibrary/ftva-etl/pull/30) - the container build will fail if there isn't a 0.3.1 version of the package on Github.

[DLSR-276]: https://uclalibrary.atlassian.net/browse/DLSR-276?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ