### PR TITLE
DLSR-272: Allow bi-directional relationship mgmt

### DIFF
--- a/charts/prod-ftvalabdata-values.yaml
+++ b/charts/prod-ftvalabdata-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/ftva-lab-data
-  tag: v1.1.1
+  tag: v1.1.2
   pullPolicy: Always
 
 nameOverride: ""

--- a/ftva_lab_data/forms.py
+++ b/ftva_lab_data/forms.py
@@ -1,6 +1,20 @@
 from django import forms
+from django.core.exceptions import ValidationError
 from django.core.validators import FileExtensionValidator
 from .models import SheetImport, RelationshipType
+
+
+def _parse_relationship_type_choice(value: str) -> tuple[bool, int] | None:
+    """Parse value of `relationship_type` field to determine direction of relationship.
+
+    :param value: Value of `relationship_type` field.
+    :return: Tuple containing a boolean indicating whether the relationship is outgoing
+        and the ID of the `RelationshipType` object, or `None` if the value is invalid.
+    """
+    prefix, remainder = value.split(":", 1)
+    if prefix not in ("outgoing", "incoming") or not remainder.isdigit():
+        return None
+    return (prefix == "outgoing", int(remainder))
 
 
 class ItemForm(forms.ModelForm):
@@ -86,9 +100,13 @@ class ItemForm(forms.ModelForm):
 
 
 class RelationshipForm(forms.Form):
-    """Form used to add relationships between records in the add-relationship modal."""
+    """Form used to add or edit relationships between records in the relationship modal.
 
-    relationship_type = forms.ModelChoiceField(queryset=RelationshipType.objects.all())
+    The choices for the `relationship_type` field are set via a custom `__init__` method.
+    See below for more details.
+    """
+
+    relationship_type = forms.ChoiceField(label="Relationship type")
     target = forms.IntegerField(
         label="Related record ID",
         min_value=1,
@@ -98,6 +116,59 @@ class RelationshipForm(forms.Form):
             }
         ),
     )
+
+    def __init__(self, *args, **kwargs):
+        """Set the choices for the `relationship_type` field.
+
+        The choices are derived from the `RelationshipType` model,
+        with the `type` field for "outgoing" relationships
+        and the `reverse_type` field for "incoming" relationships.
+        """
+        super().__init__(*args, **kwargs)
+        outgoing: list[tuple[str, str]] = []
+        incoming: list[tuple[str, str]] = []
+        # Set the choices for the `relationship_type` field,
+        # with prefixes indicating the relationship direction they represent.
+        for relationship_type in RelationshipType.objects.order_by("id"):
+            outgoing.append(
+                (f"outgoing:{relationship_type.pk}", relationship_type.type)
+            )
+            incoming.append(
+                (f"incoming:{relationship_type.pk}", relationship_type.reverse_type)
+            )
+        # Set the choices with two option groups for the dropdown: "Outgoing" and "Incoming".
+        self.fields["relationship_type"].choices = [
+            ("Outgoing", outgoing),
+            ("Incoming", incoming),
+        ]
+        # Set initial relationship type to the first outgoing relationship type,
+        # if not already set by the caller.
+        if not self.is_bound and outgoing and not self.initial.get("relationship_type"):
+            self.initial["relationship_type"] = outgoing[0][0]
+
+    def clean(self):
+        """Use prefixes on the relationship type choices
+        to determine the direction of the relationship.
+        """
+        cleaned_data = super().clean()
+        choice = cleaned_data.get("relationship_type")
+        if choice in (None, ""):
+            return cleaned_data
+        parsed = _parse_relationship_type_choice(choice)
+        if parsed is None:
+            raise ValidationError(
+                {"relationship_type": ["Invalid relationship type selection."]}
+            )
+        is_outgoing, pk = parsed
+        try:
+            relationship_type = RelationshipType.objects.get(pk=pk)
+        except RelationshipType.DoesNotExist:
+            raise ValidationError(
+                {"relationship_type": ["Invalid relationship type selection."]}
+            )
+        cleaned_data["relationship_type"] = relationship_type
+        cleaned_data["is_outgoing"] = is_outgoing
+        return cleaned_data
 
 
 class BatchUpdateForm(forms.Form):

--- a/ftva_lab_data/forms.py
+++ b/ftva_lab_data/forms.py
@@ -7,7 +7,16 @@ from .models import SheetImport, RelationshipType
 def _parse_relationship_type_choice(value: str) -> tuple[bool, int] | None:
     """Parse value of `relationship_type` field to determine direction of relationship.
 
-    :param value: Value of `relationship_type` field.
+    The information parsed from the value is used in the custom `clean` method
+    on the `RelationshipForm` to determine which `RelationshipType` object
+    should be used for the relationship at hand, and whether the relationship is
+    "outgoing" or "incoming". This direction is then used by the view to determine
+    whether the item currently in context should be
+    the source or target of the new or updated `Relationship` object.
+
+    :param value: Value of `relationship_type` field with prefix indicating direction,
+        e.g. "outgoing:123" to reference `RelationshipType` ID 123 in outgoing direction,
+        or "incoming:456" to reference `RelationshipType` ID 456 in incoming direction.
     :return: Tuple containing a boolean indicating whether the relationship is outgoing
         and the ID of the `RelationshipType` object, or `None` if the value is invalid.
     """

--- a/ftva_lab_data/templates/partials/relationship_modal_content.html
+++ b/ftva_lab_data/templates/partials/relationship_modal_content.html
@@ -12,15 +12,16 @@
         {% csrf_token %}
         <div class="modal-body">
             {% comment %}
-            Source is presumed to be the current record on the `view_item` page,
-            so it's not actually included in the `RelationshipForm` rendered here.
-            We display it for reference, but it's not editable. Hence the HTML field outside the Bootstrap form.
+            The current record is rendered for reference as a read-only input field.
+            Whether it is set as source or target depends on the relationship type selected,
+            with direction determined by the prefix on the relationship type choice.
             {% endcomment %}
             <div class="mb-3">
                 <label for="sourceDisplay" class="form-label">This record</label>
                 <input type="text" readonly class="form-control-plaintext" id="sourceDisplay" value="{{ item }}" />
             </div>
-            {% bootstrap_form form %}
+            {% bootstrap_field form.relationship_type %}
+            {% bootstrap_field form.target %}
         </div>
         <div class="modal-footer">
             <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>

--- a/ftva_lab_data/templates/release_notes.html
+++ b/ftva_lab_data/templates/release_notes.html
@@ -4,6 +4,12 @@
 <h3>Release Notes</h3>
 <hr />
 
+<h4>1.1.2</h4>
+<p><i>April 10, 2026</i></p>
+<ul>
+    <li>Allow relationships to be managed in both directions from item detail view.</li>
+</ul>
+
 <h4>1.1.1</h4>
 <p><i>April 8, 2026</i></p>
 <ul>

--- a/ftva_lab_data/tests.py
+++ b/ftva_lab_data/tests.py
@@ -1639,7 +1639,7 @@ class AddRelationshipViewTestCase(TestCase):
         response = self.client.post(
             url,
             {
-                "relationship_type": self.relationship_type_a.id,
+                "relationship_type": f"outgoing:{self.relationship_type_a.id}",
                 "target": self.target_item.id,
             },
         )
@@ -1653,7 +1653,7 @@ class AddRelationshipViewTestCase(TestCase):
         response = self.client.post(
             url,
             {
-                "relationship_type": self.relationship_type_a.id,
+                "relationship_type": f"outgoing:{self.relationship_type_a.id}",
                 # Invalid because no target is provided
             },
         )
@@ -1666,7 +1666,7 @@ class AddRelationshipViewTestCase(TestCase):
             url,
             {
                 "target": 999999,
-                "relationship_type": self.relationship_type_a.id,
+                "relationship_type": f"outgoing:{self.relationship_type_a.id}",
             },
         )
 
@@ -1685,7 +1685,7 @@ class AddRelationshipViewTestCase(TestCase):
             url,
             {
                 "target": self.target_item.id,
-                "relationship_type": self.relationship_type_a.id,
+                "relationship_type": f"outgoing:{self.relationship_type_a.id}",
             },
         )
 
@@ -1717,7 +1717,7 @@ class AddRelationshipViewTestCase(TestCase):
         response = self.client.post(
             url,
             {
-                "relationship_type": self.relationship_type_b.id,  # change to type B
+                "relationship_type": f"outgoing:{self.relationship_type_b.id}",  # change to type B
                 "target": self.target_item.id,
             },
         )
@@ -1741,3 +1741,25 @@ class AddRelationshipViewTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertFalse(Relationship.objects.filter(id=relationship.id).exists())
         self.assertContains(response, "No relationships found.")
+
+    def test_post_incoming_choice_swaps_source_and_target(self):
+        url = reverse("add_relationship", args=[self.source_item.id])
+        response = self.client.post(
+            url,
+            {
+                # Selecting an Incoming (reverse_type) option
+                # should result in target being used as source on the relationship.
+                "relationship_type": f"incoming:{self.relationship_type_a.id}",
+                "target": self.target_item.id,
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        relationship = Relationship.objects.get(
+            source=self.target_item,
+            target=self.source_item,
+            relationship_type=self.relationship_type_a,
+        )
+        # Assert target item is source on relationship, and vice versa
+        self.assertEqual(relationship.source_id, self.target_item.id)
+        self.assertEqual(relationship.target_id, self.source_item.id)

--- a/ftva_lab_data/views.py
+++ b/ftva_lab_data/views.py
@@ -868,29 +868,26 @@ def add_edit_relationship(
     relationship = None
     initial_data = {}
     is_edit: bool = relationship_id is not None
-    # Default to adding outgoing relationship
-    is_outgoing: bool = True
 
+    # Set initial data for form when editing an existing relationship
     if is_edit:
         relationship = get_object_or_404(Relationship, id=relationship_id)
         # If relationship's source is the current item, it's outgoing; otherwise it's incoming
         is_outgoing = relationship.source_id == item.id
-        # Set initial data for form, including relationship type and target ID
         initial_data = {
-            "relationship_type": relationship.relationship_type_id,
-            # If relationship is incoming, target needs to be reversed for form display
+            "relationship_type": (
+                f"outgoing:{relationship.relationship_type_id}"
+                if is_outgoing
+                else f"incoming:{relationship.relationship_type_id}"
+            ),
+            # Target needs to be reversed if relationship is incoming
             "target": relationship.target_id if is_outgoing else relationship.source_id,
         }
 
+    # Instantiate form with initial data
     form = RelationshipForm(request.POST or None, initial=initial_data)
 
-    # Set what options are displayed in the relationship type select field:
-    # `RelationshipType.type` for outgoing relationships;
-    # `RelationshipType.reverse_type` for incoming relationships.
-    form.fields["relationship_type"].label_from_instance = (
-        (lambda obj: obj.type) if is_outgoing else (lambda obj: obj.reverse_type)
-    )
-
+    # Handle POST request
     if request.method == "POST":
         if form.is_valid():
             try:
@@ -908,8 +905,11 @@ def add_edit_relationship(
                     },
                 )
 
+            # `relationship_type` and `is_outgoing`
+            # are determined using the form's custom `clean` method.
+            # See `forms.py` for more details.
             relationship_type = form.cleaned_data["relationship_type"]
-            # Set source and target based on whether relationship is outgoing or incoming
+            is_outgoing = form.cleaned_data["is_outgoing"]
             source_item = item if is_outgoing else related_item
             target_item = related_item if is_outgoing else item
 
@@ -990,7 +990,7 @@ def add_edit_relationship(
             },
         )
 
-    # If GET request, render pre-configured form
+    # Handle GET request
     return render(
         request,
         "partials/relationship_modal_content.html",


### PR DESCRIPTION
Implements [DLSR-272](https://uclalibrary.atlassian.net/browse/DLSR-272)

### Acceptance criteria
- [X] Relationships can be added and edited in both “outgoing” and “incoming” directions from item detail page

### Description
This PR improves the functionality added in #99 to allow bi-directional relationship management from an item's detail page. The relationship type drop-down now displays both `type` and `reverse_type` from the `RelationshipType` objects, grouped under the headings "Outgoing" and "Incoming" respectively.

When a user selects one of these options, the direction of the relationship is parsed from prefixes encoded in the option's value. Parsing of the direction prefixes is handled by overrides of the `__init__` and `clean` methods on the `RelationshipForm`. The view uses the information parsed from the form to determine whether the item currently in context (i.e. the one being viewed on the detail page) should be set as the `source` or the `target` for the relationship being added or edited. Deleting relationships remains unchanged.

### Testing
1 new test is added to cover the "incoming" direction, and the other tests are updated to reflect the new prefixes on the `relationship_type` choice values. 88 tests for the application in all.

### Screencap
![screencap](https://github.com/user-attachments/assets/be8eaec5-ffc1-4094-ae0a-8199809cd692)


[DLSR-272]: https://uclalibrary.atlassian.net/browse/DLSR-272?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ