### PR TITLE
DLSR-380: Add view for retrieving filtered record sets

### DIFF
--- a/charts/prod-ftvalabdata-values.yaml
+++ b/charts/prod-ftvalabdata-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/ftva-lab-data
-  tag: v1.1.2
+  tag: v1.2.0
   pullPolicy: Always
 
 nameOverride: ""

--- a/ftva_lab_data/templates/release_notes.html
+++ b/ftva_lab_data/templates/release_notes.html
@@ -4,6 +4,12 @@
 <h3>Release Notes</h3>
 <hr />
 
+<h4>1.2.0</h4>
+<p><i>June 16, 2026</i></p>
+<ul>
+    <li>Refactor `get_records` view to allow filtering, alongside existing pagination of records.</li>
+</ul>
+
 <h4>1.1.2</h4>
 <p><i>April 10, 2026</i></p>
 <ul>

--- a/ftva_lab_data/tests.py
+++ b/ftva_lab_data/tests.py
@@ -1547,15 +1547,15 @@ class GetRecordsTestCase(TestCase):
         base64_credentials = base64.b64encode(credentials.encode()).decode()
         http_auth_string = f"Basic {base64_credentials}"
         self.client = Client(HTTP_AUTHORIZATION=http_auth_string)
+        self.url = reverse("get_records")
 
         # Create 200 test records
         for i in range(200):
             SheetImport.objects.create(file_name=f"test_file_{i}")
 
     def test_get_records_default(self):
-        url = reverse("get_records")
         first_record = SheetImport.objects.order_by("id").first()
-        response = self.client.get(url)
+        response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)
 
         # First result should be the first record from database
@@ -1593,8 +1593,7 @@ class GetRecordsTestCase(TestCase):
                     .first()
                 )
                 total_records = SheetImport.objects.count()
-                url = reverse("get_records")
-                response = self.client.get(url, {"offset": offset, "limit": limit})
+                response = self.client.get(self.url, {"offset": offset, "limit": limit})
                 self.assertEqual(response.status_code, 200)
 
                 # If offset > total number of records,
@@ -1620,8 +1619,7 @@ class GetRecordsTestCase(TestCase):
         for offset, limit in bad_test_cases:
             with self.subTest(offset=offset, limit=limit):
                 first_record = SheetImport.objects.order_by("id").first()
-                url = reverse("get_records")
-                response = self.client.get(url, {"offset": offset, "limit": limit})
+                response = self.client.get(self.url, {"offset": offset, "limit": limit})
                 self.assertEqual(response.status_code, 200)
                 # Should always return 100 records by default
                 self.assertEqual(len(response.json()["records"]), 100)
@@ -1629,8 +1627,7 @@ class GetRecordsTestCase(TestCase):
                 self.assertEqual(response.json()["records"][0]["id"], first_record.id)
 
     def test_get_records_correct_order(self):
-        url = reverse("get_records")
-        response = self.client.get(url)
+        response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)
 
         # Should return records in ascending order by ID
@@ -1641,24 +1638,35 @@ class GetRecordsTestCase(TestCase):
         self.assertEqual(result_ids, expected_ids)
 
     def test_get_records_with_query(self):
-        url = reverse("get_records")
         # Filter for record with `file_name=test_file_100`. There should be only one.
         response = self.client.get(
-            url, {"query": "test_file_100", "fields": "file_name"}
+            self.url, {"query": "test_file_100", "fields": "file_name"}
         )
         self.assertEqual(response.status_code, 200)
         # Should return 1 record
         self.assertEqual(len(response.json()["records"]), 1)
         self.assertEqual(response.json()["records"][0]["file_name"], "test_file_100")
 
-    def test_get_records_with_bad_query(self):
-        url = reverse("get_records")
-        response = self.client.get(url, {"query": "foobar", "fields": "baz_buz"})
+    def test_get_records_with_bad_field(self):
+        # Bad field name values should result in a 400 error indicating field does not exist
+        response = self.client.get(self.url, {"query": "foobar", "fields": "baz_buz"})
         self.assertContains(
             response=response,
             status_code=400,
             text="Cannot resolve keyword 'baz_buz' into field.",
             count=1,
+        )
+
+    def test_get_records_with_bad_keys(self):
+        # Bad keys in query params should result in a 400 error indicating invalid query parameters
+        response = self.client.get(
+            self.url,
+            {"foo_bar": "baz_buz"},
+        )
+        self.assertContains(
+            response=response,
+            status_code=400,
+            text="Invalid query parameters. Valid keys are: ['query', 'fields', 'offset', 'limit']",
         )
 
 

--- a/ftva_lab_data/tests.py
+++ b/ftva_lab_data/tests.py
@@ -1133,16 +1133,27 @@ class ExtractInventoryNumbersTestCase(TestCase):
 class MetadataTestCase(TestCase):
     """Tests associated with MAMS ETL metadata, from the Django perspective."""
 
-    fixtures = ["dropdown_fields.json"]
+    fixtures = ["dropdown_fields.json", "relationship_types.json"]
 
     def setUp(self):
         # General data is not important. However, related objects like AudioClass
         # are not directly serializable into JSON. Nor is uuid, which is set
         # automatically on SheetImport creation.
-        self.item_for_metadata = SheetImport.objects.create(
-            file_name="Some file",
-            inventory_number="inv_no",
+        self.record_a = SheetImport.objects.create(
+            file_name="Some file A",
+            inventory_number="inv_no_1",
             audio_class=AudioClass.objects.get(pk=1),
+        )
+        self.record_b = SheetImport.objects.create(
+            file_name="Some file B",
+            inventory_number="inv_no_2",
+        )
+
+        # Create relationship between the items
+        Relationship.objects.create(
+            source=self.record_a,
+            target=self.record_b,
+            relationship_type=RelationshipType.objects.get(pk=1),
         )
 
     def test_django_data_is_serializable(self):
@@ -1150,7 +1161,7 @@ class MetadataTestCase(TestCase):
         # the SheetImport model but not handled correctly in transform_record_to_dict().
         # No need to test every possible field explicitly; the test item
         # created in setUp() has one example, AudioClass, which is enough.
-        django_data = transform_record_to_dict(self.item_for_metadata)
+        django_data = transform_record_to_dict(self.record_a)
 
         # If it's not serializable to JSON, this will raise a TypeError.
         # Here we're just confirming that the JSON conversion succeeds,
@@ -1160,7 +1171,7 @@ class MetadataTestCase(TestCase):
     def test_uuid_is_serializable(self):
         # This covers a specific case, UUID, which as a data type is not
         # serializable.
-        django_data = transform_record_to_dict(self.item_for_metadata)
+        django_data = transform_record_to_dict(self.record_a)
 
         # Make sure there's a UUID in the data, as a string, not a UUID().
         uuid = django_data.get("uuid")
@@ -1173,6 +1184,33 @@ class MetadataTestCase(TestCase):
         # Double-check that the troublesome data
         # ("uuid": "value unimportant") is in fact included.
         self.assertIn('"uuid":', json_data)
+
+    def test_relationships_are_serializable(self):
+        # `transform_record_to_dict()` should serialize
+        # Relationships involving two SheetImport objects,
+        # representing the relationships as two lists of dicts:
+        # `outgoing_relationships` and `incoming_relationships`
+        dict_a = transform_record_to_dict(self.record_a)
+        # Should be outgoing relationship: Record A hasTrack Record B
+        self.assertEqual(
+            dict_a["outgoing_relationships"][0]["target_uuid"], str(self.record_b.uuid)
+        )
+        self.assertEqual(
+            dict_a["outgoing_relationships"][0]["relationship_type"], "hasTrack"
+        )
+        # Should be no incoming relationships on Record A
+        self.assertEqual(dict_a["incoming_relationships"], [])
+
+        dict_b = transform_record_to_dict(self.record_b)
+        # Should be incoming relationship: Record B isTrackOf Record A
+        self.assertEqual(
+            dict_b["incoming_relationships"][0]["source_uuid"], str(self.record_a.uuid)
+        )
+        self.assertEqual(
+            dict_b["incoming_relationships"][0]["relationship_type"], "isTrackOf"
+        )
+        # Should be no outgoing relationships on Record B
+        self.assertEqual(dict_b["outgoing_relationships"], [])
 
 
 class SetHardDriveLocationTestCase(TestCase):
@@ -1526,19 +1564,69 @@ class GetRecordsTestCase(TestCase):
         self.assertEqual(len(response.json()["records"]), 100)
 
     def test_get_records_with_offset_and_limit(self):
-        offset = 50
-        limit = 100
-        url = reverse("get_records")
-        test_record = (
-            SheetImport.objects.all().order_by("id")[offset : offset + limit].first()
-        )
-        response = self.client.get(url, {"offset": offset, "limit": limit})
-        self.assertEqual(response.status_code, 200)
+        # Test cases are tuples of (offset, limit)
+        good_test_cases = [
+            (50, 100),
+            (42, 75),
+            # limit > total number of records should return remaining records
+            (100, 200),
+            # offset > total number of records should return empty list
+            (300, 100),
+        ]
 
-        # First result should be the 51st record from database
-        self.assertEqual(response.json()["records"][0]["id"], test_record.id)
-        # Should return 100 records starting from the 51st record
-        self.assertEqual(len(response.json()["records"]), 100)
+        bad_test_cases = [
+            # negative integers
+            (-1, 100),
+            (50, -1),
+            (-1, -1),
+            # non-integers
+            ("foo", "bar"),
+            (50.5, 100.1),
+        ]
+
+        for offset, limit in good_test_cases:
+            with self.subTest(offset=offset, limit=limit):
+                # Get the first record from the database for the slice of records being tested
+                expected_first_record = (
+                    SheetImport.objects.all()
+                    .order_by("id")[offset : offset + limit]
+                    .first()
+                )
+                total_records = SheetImport.objects.count()
+                url = reverse("get_records")
+                response = self.client.get(url, {"offset": offset, "limit": limit})
+                self.assertEqual(response.status_code, 200)
+
+                # If offset > total number of records,
+                # should return empty list
+                if offset > total_records:
+                    self.assertEqual(len(response.json()["records"]), 0)
+                # Else if offset + limit > total number of records,
+                # should return the remaining records
+                elif offset + limit > total_records:
+                    self.assertEqual(
+                        len(response.json()["records"]), total_records - offset
+                    )
+                else:
+                    self.assertEqual(len(response.json()["records"]), limit)
+
+                # If there are records, the first record
+                # should match that expected from the database
+                if response.json()["records"]:
+                    self.assertEqual(
+                        response.json()["records"][0]["id"], expected_first_record.id
+                    )
+
+        for offset, limit in bad_test_cases:
+            with self.subTest(offset=offset, limit=limit):
+                first_record = SheetImport.objects.order_by("id").first()
+                url = reverse("get_records")
+                response = self.client.get(url, {"offset": offset, "limit": limit})
+                self.assertEqual(response.status_code, 200)
+                # Should always return 100 records by default
+                self.assertEqual(len(response.json()["records"]), 100)
+                # First record should be the first record from database
+                self.assertEqual(response.json()["records"][0]["id"], first_record.id)
 
     def test_get_records_correct_order(self):
         url = reverse("get_records")

--- a/ftva_lab_data/tests.py
+++ b/ftva_lab_data/tests.py
@@ -1493,8 +1493,8 @@ class DropdownFieldsTestCase(TestCase):
                 self.assertNotIn(deleted_obj.pk, choices)
 
 
-class GetAllRecordsTestCase(TestCase):
-    """Tests for the get_all_records view."""
+class GetRecordsTestCase(TestCase):
+    """Tests for the get_records view."""
 
     fixtures = ["sample_data.json", "groups_and_permissions.json"]
 
@@ -1514,8 +1514,8 @@ class GetAllRecordsTestCase(TestCase):
         for i in range(200):
             SheetImport.objects.create(file_name=f"test_file_{i}")
 
-    def test_get_all_records_default(self):
-        url = reverse("get_all_records")
+    def test_get_records_default(self):
+        url = reverse("get_records")
         first_record = SheetImport.objects.order_by("id").first()
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
@@ -1525,10 +1525,10 @@ class GetAllRecordsTestCase(TestCase):
         # Should return 100 records by default
         self.assertEqual(len(response.json()["records"]), 100)
 
-    def test_get_all_records_with_offset_and_limit(self):
+    def test_get_records_with_offset_and_limit(self):
         offset = 50
         limit = 100
-        url = reverse("get_all_records")
+        url = reverse("get_records")
         test_record = (
             SheetImport.objects.all().order_by("id")[offset : offset + limit].first()
         )
@@ -1540,8 +1540,8 @@ class GetAllRecordsTestCase(TestCase):
         # Should return 100 records starting from the 51st record
         self.assertEqual(len(response.json()["records"]), 100)
 
-    def test_get_all_records_correct_order(self):
-        url = reverse("get_all_records")
+    def test_get_records_correct_order(self):
+        url = reverse("get_records")
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 
@@ -1551,6 +1551,27 @@ class GetAllRecordsTestCase(TestCase):
             record.id for record in SheetImport.objects.all().order_by("id")[0:100]
         ]
         self.assertEqual(result_ids, expected_ids)
+
+    def test_get_records_with_query(self):
+        url = reverse("get_records")
+        # Filter for record with `file_name=test_file_100`. There should be only one.
+        response = self.client.get(
+            url, {"query": "test_file_100", "fields": "file_name"}
+        )
+        self.assertEqual(response.status_code, 200)
+        # Should return 1 record
+        self.assertEqual(len(response.json()["records"]), 1)
+        self.assertEqual(response.json()["records"][0]["file_name"], "test_file_100")
+
+    def test_get_records_with_bad_query(self):
+        url = reverse("get_records")
+        response = self.client.get(url, {"query": "foobar", "fields": "baz_buz"})
+        self.assertContains(
+            response=response,
+            status_code=400,
+            text="Cannot resolve keyword 'baz_buz' into field.",
+            count=1,
+        )
 
 
 class RelationshipTestCase(TestCase):

--- a/ftva_lab_data/urls.py
+++ b/ftva_lab_data/urls.py
@@ -32,7 +32,6 @@ urlpatterns = [
     path("logs/<int:line_count>", views.show_log, name="show_log"),
     path("release_notes/", views.release_notes, name="release_notes"),
     path("records/", views.get_records, name="get_records"),
-    # path("records/filtered/", views.get_filtered_records, name="get_filtered_records"),
     path("records/<int:record_id>", views.get_record, name="get_record"),
     path(
         "records/uuid/<str:uuid>", views.get_record_by_uuid, name="get_record_by_uuid"

--- a/ftva_lab_data/urls.py
+++ b/ftva_lab_data/urls.py
@@ -31,7 +31,8 @@ urlpatterns = [
     path("logs/", views.show_log, name="show_log"),
     path("logs/<int:line_count>", views.show_log, name="show_log"),
     path("release_notes/", views.release_notes, name="release_notes"),
-    path("records/", views.get_all_records, name="get_all_records"),
+    path("records/", views.get_records, name="get_records"),
+    # path("records/filtered/", views.get_filtered_records, name="get_filtered_records"),
     path("records/<int:record_id>", views.get_record, name="get_record"),
     path(
         "records/uuid/<str:uuid>", views.get_record_by_uuid, name="get_record_by_uuid"

--- a/ftva_lab_data/views.py
+++ b/ftva_lab_data/views.py
@@ -432,6 +432,16 @@ def get_records(request: HttpRequest) -> JsonResponse:
     :param request: The HTTP request object.
     :return: JSON response containing records and total count.
     """
+    # Guard against unexpected keys in the query parameters,
+    # while allowing for expected keys to be missing
+    expected_keys = ["query", "fields", "offset", "limit"]
+    if any(key not in expected_keys for key in request.GET.keys()):
+        message = f"Invalid query parameters. Valid keys are: {expected_keys}"
+        return JsonResponse(
+            {"error": message},
+            status=400,
+        )
+
     # All params are optional. If none are provided, all records are returned.
     query: str = request.GET.get("query", "")
     fields_raw = request.GET.get("fields", "")

--- a/ftva_lab_data/views.py
+++ b/ftva_lab_data/views.py
@@ -435,12 +435,20 @@ def get_records(request: HttpRequest) -> JsonResponse:
     # All params are optional. If none are provided, all records are returned.
     query: str = request.GET.get("query", "")
     fields_raw = request.GET.get("fields", "")
-    offset_raw = request.GET.get("offset")
+    offset_raw = request.GET.get("offset", 0)
     limit_raw = request.GET.get("limit", 100)
 
-    # Make sure offset and limit are integers, if provided
-    offset = int(offset_raw) if offset_raw else None
-    limit = int(limit_raw) if limit_raw else None
+    # If provided, make sure offset and limit are integers,
+    # reverting to defaults if they cannot be coerced to int
+    try:
+        offset, limit = int(offset_raw), int(limit_raw)
+    except ValueError:
+        offset, limit = 0, 100
+
+    # Handle negative values for offset or limit,
+    # reverting to defaults if either is negative
+    if offset < 0 or limit < 0:
+        offset, limit = 0, 100
 
     # Split fields into a list of strings if provided
     fields: list[str] = [f.strip() for f in fields_raw.split(",") if f.strip()]
@@ -450,15 +458,12 @@ def get_records(request: HttpRequest) -> JsonResponse:
     except FieldError as e:
         return JsonResponse({"error": str(e)}, status=400)
     total_records = queryset.count()
-    # Apply offset/limit pagination only if either is provided
-    if offset and limit:
-        records = queryset[offset : offset + limit]
-    elif offset:
-        records = queryset[offset:]
-    elif limit:
-        records = queryset[:limit]
-    else:
-        records = queryset
+    # Apply offset/limit pagination
+    # Because of defaults set above,
+    # we can safely assume offset and limit are non-negative integers,
+    # so this slice will always give us the desired result.
+    # E.g. offset=0, limit=100 -> [0 : 0 + 100] = [0:100]
+    records = queryset[offset : offset + limit]
 
     records_data = [transform_record_to_dict(record) for record in records]
     response_data = {

--- a/ftva_lab_data/views.py
+++ b/ftva_lab_data/views.py
@@ -3,6 +3,7 @@ from django.contrib import messages
 from django.contrib.auth import get_user_model
 from django.contrib.auth.decorators import login_required, permission_required
 from django.core.paginator import Paginator
+from django.core.exceptions import FieldError
 from django.http import HttpRequest, HttpResponse, StreamingHttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404, render, redirect
 from django.template.loader import render_to_string
@@ -418,21 +419,51 @@ def get_record_by_uuid(request: HttpRequest, uuid: str) -> JsonResponse:
 
 
 @basic_auth_required
-def get_all_records(request: HttpRequest) -> JsonResponse:
-    """Get all SheetImport records from the database,
-    serialized as JSON. Intended for API use.
+def get_records(request: HttpRequest) -> JsonResponse:
+    """Get SheetImport records from the database,
+    with optional filtering and pagination params for API use.
+
+    Query params:
+        query: string for searching/filtering (optional)
+        fields: comma-separated list of fields to search in (optional)
+        offset: starting record for pagination (optional, defaults to 0)
+        limit: number of results to return (optional, defaults to 100)
 
     :param request: The HTTP request object.
-    :return: JSON response containing records paginated by offset and limit.
+    :return: JSON response containing records and total count.
     """
-    # Offset and limit set via query parameters
-    offset = int(request.GET.get("offset", 0))
-    limit = int(request.GET.get("limit", 100))
-    records = SheetImport.objects.all().order_by("id")[offset : offset + limit]
+    # All params are optional. If none are provided, all records are returned.
+    query: str = request.GET.get("query", "")
+    fields_raw = request.GET.get("fields", "")
+    offset_raw = request.GET.get("offset")
+    limit_raw = request.GET.get("limit", 100)
+
+    # Make sure offset and limit are integers, if provided
+    offset = int(offset_raw) if offset_raw else None
+    limit = int(limit_raw) if limit_raw else None
+
+    # Split fields into a list of strings if provided
+    fields: list[str] = [f.strip() for f in fields_raw.split(",") if f.strip()]
+
+    try:
+        queryset = get_search_result_items(query, fields)
+    except FieldError as e:
+        return JsonResponse({"error": str(e)}, status=400)
+    total_records = queryset.count()
+    # Apply offset/limit pagination only if either is provided
+    if offset and limit:
+        records = queryset[offset : offset + limit]
+    elif offset:
+        records = queryset[offset:]
+    elif limit:
+        records = queryset[:limit]
+    else:
+        records = queryset
+
     records_data = [transform_record_to_dict(record) for record in records]
     response_data = {
         "records": records_data,
-        "total_records": SheetImport.objects.count(),
+        "total_records": total_records,
     }
     return JsonResponse(response_data)
 

--- a/ftva_lab_data/views_utils.py
+++ b/ftva_lab_data/views_utils.py
@@ -508,6 +508,24 @@ def transform_record_to_dict(record: SheetImport) -> dict:
         # or "" to avoid serializing None to "None"
         record_data[key] = str(record_data.get(key) or "")
 
+    # Add Relationships data
+    outgoing_relationships = record.outgoing_relationships.all()
+    incoming_relationships = record.incoming_relationships.all()
+    record_data["outgoing_relationships"] = [
+        {
+            "target_uuid": relationship.target.uuid,
+            "relationship_type": relationship.relationship_type.type,
+        }
+        for relationship in outgoing_relationships
+    ]
+    record_data["incoming_relationships"] = [
+        {
+            "source_uuid": relationship.source.uuid,
+            "relationship_type": relationship.relationship_type.type,
+        }
+        for relationship in incoming_relationships
+    ]
+
     return record_data
 
 

--- a/ftva_lab_data/views_utils.py
+++ b/ftva_lab_data/views_utils.py
@@ -513,15 +513,17 @@ def transform_record_to_dict(record: SheetImport) -> dict:
     incoming_relationships = record.incoming_relationships.all()
     record_data["outgoing_relationships"] = [
         {
-            "target_uuid": relationship.target.uuid,
+            "target_uuid": str(relationship.target.uuid),
+            # Outgoing should be `relationship_type.type`
             "relationship_type": relationship.relationship_type.type,
         }
         for relationship in outgoing_relationships
     ]
     record_data["incoming_relationships"] = [
         {
-            "source_uuid": relationship.source.uuid,
-            "relationship_type": relationship.relationship_type.type,
+            "source_uuid": str(relationship.source.uuid),
+            # Incoming should be `relationship_type.reverse_type`
+            "relationship_type": relationship.relationship_type.reverse_type,
         }
         for relationship in incoming_relationships
     ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==5.2.10
+Django==5.2.14
 django-bootstrap5==25.1
 django-simple-history==3.8.0 
 psycopg==3.2.9
@@ -9,4 +9,4 @@ pandas==2.2.3
 numpy==2.3.5
 openpyxl==3.1.5
 # Local package for Alma & Filemaker integration.
-git+https://github.com/UCLALibrary/ftva-etl.git@v0.3.1
+git+https://github.com/UCLALibrary/ftva-etl.git@v0.3.4


### PR DESCRIPTION
Implements [DLSR-380](https://uclalibrary.atlassian.net/browse/DLSR-380)

### Acceptance criteria
- [X] A new view and URL route are added to allow consumers to fetch a filtered set of records, using a provided query string and field name
- [X] Serialized response data is updated to include relationship information

### Description
This PR updates the `get_all_records` view to `get_records` and adds optional query parameters for filtering, in addition to the params that provide pagination. Now, the `/records/` URL responds with all records by default, paginated in groups of 100 as before. However, new parameters `query` and `fields` can be included with the request to get a filtered set of records, using `view_utils.get_search_result_items`. Meanwhile, `view_utils.transform_record_to_dict` is updated to add relationship data to the records returned by `get_records`.

In the immediate term, these changes are intended to allow the `ftva_mams_data.generate_metadata` script to retrieve batches of records directly from the Digital Data app, rather than relying on an external CSV file as input. The relationships data in particular will be useful, as the script labels records as `assets` or `tracks` in the final JSON metadata output using those relationships.

For consistency's sake, `ftva_etl.DigitalDataClient` can provide a wrapper for this refactored view, then `ftva_mams_data.generate_metadata` can consumer that wrapper.

### Testing
A couple new tests are added to cover the filtering feature, and existing tests are updated to align with the change to the view function's name. There are now 90 tests overall, all passing.

[DLSR-380]: https://uclalibrary.atlassian.net/browse/DLSR-380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ