### PR TITLE
DLSR-518: update `ftva-etl` to `v0.6.3` and Django to `v5.2.15`

### DIFF
--- a/charts/prod-ftvalabdata-values.yaml
+++ b/charts/prod-ftvalabdata-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/ftva-lab-data
-  tag: v1.2.0
+  tag: v1.2.1
   pullPolicy: Always
 
 nameOverride: ""

--- a/ftva_lab_data/templates/release_notes.html
+++ b/ftva_lab_data/templates/release_notes.html
@@ -9,7 +9,6 @@
 <ul>
     <li>Update `ftva-etl` to `v0.6.3`.</li>
     <li>Update `Django` to `v5.2.15`.</li>
-
 </ul>
 
 <h4>1.2.0</h4>

--- a/ftva_lab_data/templates/release_notes.html
+++ b/ftva_lab_data/templates/release_notes.html
@@ -4,6 +4,14 @@
 <h3>Release Notes</h3>
 <hr />
 
+<h4>1.2.1</h4>
+<p><i>August 4, 2026</i></p>
+<ul>
+    <li>Update `ftva-etl` to `v0.6.3`.</li>
+    <li>Update `Django` to `v5.2.15`.</li>
+
+</ul>
+
 <h4>1.2.0</h4>
 <p><i>June 16, 2026</i></p>
 <ul>

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ pandas==2.2.3
 numpy==2.3.5
 openpyxl==3.1.5
 # Local package for Alma & Filemaker integration.
-git+https://github.com/UCLALibrary/ftva-etl.git@v0.3.4
+git+https://github.com/UCLALibrary/ftva-etl.git@v0.6.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==5.2.14
+Django==5.2.15
 django-bootstrap5==25.1
 django-simple-history==3.8.0 
 psycopg==3.2.9


### PR DESCRIPTION
Implements [DLSR-518](https://uclalibrary.atlassian.net/browse/DLSR-518)

## Acceptance criteria
- [X] Update the `ftva_etl` package in Digital Data to bring in all the recent changes
- [X] Update Django to patch security issue
- [X] Make sure all tests still pass

## Description
Updates the `ftva-etl` and Django dependencies in `requirements.txt`.

**Note:** business logic related to the legacy ETL process in `ftva-etl` is still out-of-spec, and will need to be revised separately. That affects the Digital Data app in that the `View Metadata` button on relevant records displays the out-of-spec JSON metadata. Since the focus is on NDM ETL for the time being, this can be addressed in the future; just noting it for now.

## Testing
All 92 tests still pass after updating.

[DLSR-518]: https://uclalibrary.atlassian.net/browse/DLSR-518?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ