### PR TITLE
DLSR-532: Update ftva-etl and improve error handling

### DIFF
--- a/charts/prod-ftvalabdata-values.yaml
+++ b/charts/prod-ftvalabdata-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/ftva-lab-data
-  tag: v1.2.1
+  tag: v1.2.2
   pullPolicy: Always
 
 nameOverride: ""

--- a/ftva_lab_data/templates/release_notes.html
+++ b/ftva_lab_data/templates/release_notes.html
@@ -4,6 +4,13 @@
 <h3>Release Notes</h3>
 <hr />
 
+<h4>1.2.2</h4>
+<p><i>August 7, 2026</i></p>
+<ul>
+    <li>Update `ftva-etl` to `v0.7.0`.</li>
+    <li>Add error handling for metadata generation via "View Metadata" button.</li>
+</ul>
+
 <h4>1.2.1</h4>
 <p><i>August 4, 2026</i></p>
 <ul>

--- a/ftva_lab_data/views.py
+++ b/ftva_lab_data/views.py
@@ -658,17 +658,18 @@ def generate_metadata_json(request: HttpRequest, record_id: int) -> HttpResponse
     # If we have exactly one FM record and no more than one Alma record,
     # generate metadata.
     if bib_records_count <= 1 and fm_records_count == 1:
-        if bib_records_count == 1:
+        try:
             metadata = get_mams_metadata(
                 digital_data_record=django_record_data,
                 filemaker_record=fm_records[0],
-                bib_record=filtered_bib_records[0],
+                bib_record=filtered_bib_records[0] if filtered_bib_records else None,
             )
-        else:
-            metadata = get_mams_metadata(
-                digital_data_record=django_record_data,
-                filemaker_record=fm_records[0],
-                bib_record=None,
+        except Exception as e:
+            message = f"Error generating metadata: {e}"
+            return render(
+                request,
+                "partials/metadata_modal_content.html",
+                {"message": message, "is_error": True},
             )
         # Format the metadata as JSON for display in the template
         metadata_json = json.dumps(metadata, indent=2)

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ pandas==2.2.3
 numpy==2.3.5
 openpyxl==3.1.5
 # Local package for Alma & Filemaker integration.
-git+https://github.com/UCLALibrary/ftva-etl.git@v0.6.3
+git+https://github.com/UCLALibrary/ftva-etl.git@v0.7.0


### PR DESCRIPTION
Implements [DLSR-532](https://uclalibrary.atlassian.net/browse/DLSR-532)

## Acceptance criteria
- [X] The `ftva-etl` package is updated to `v0.7.0` to bring in recent changes
- [X] Error handling is improved so that the “View Metadata” modal displays error messages raised by `ftva-etl` (such as that raised by invalid `media_type`) rather than hanging

## Description
Updates the `ftva-etl` package to `v0.7.0` and improves metadata preview error handling. The “View Metadata” flow now catches exceptions from `get_mams_metadata` and renders them in the modal instead of leaving the UI in a loading state.

## Testing
No new unit tests were added, and the existing 92 tests are still passing.

To manually confirm that the "View Metadata" modal is working as expected, please:
1. open a record from a previous batch that has completely valid data (e.g., arbitrarily, `Record ID 8052`) and confirm the JSON rendered in the "View Metadata" modal is as expected from the `ftva-etl@v0.7.0` changes (i.e. `inventory_id` is a list of strings, `media_type` is lowercase).
2. open a record that triggers an `ftva-etl` error (e.g., again arbitrarily, `Record ID 11`) and confirm the modal shows the error message and does not hang in a loading state.

[DLSR-532]: https://uclalibrary.atlassian.net/browse/DLSR-532?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ