### PR TITLE
Update clusterissuer to Certinext

### DIFF
--- a/charts/prod-ftvalabdata-values.yaml
+++ b/charts/prod-ftvalabdata-values.yaml
@@ -23,7 +23,7 @@ ingress:
     kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
-    cert-manager.io/cluster-issuer: sectigo-acme-clusterissuer
+    cert-manager.io/cluster-issuer: certinext
     kubernetes.io/tls-acme: "true"
 
   hosts:


### PR DESCRIPTION
We are migrating our automated certificate management away from Sectigo to the campus replacement Certinext. This change will ensure certificates get automatically renewed on our k8s applications.